### PR TITLE
fix: Anonymize the transaction name for better performance data

### DIFF
--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -59,15 +59,25 @@ func (env *environment) newRouter() (*httprouter.Router, error) {
 		return nil, err
 	}
 
+	routes := []struct {
+		method  string
+		path    string
+		handler http.HandlerFunc
+	}{
+		{http.MethodGet, "/organizations/:organization_id/filters", env.getFilters},
+		{http.MethodGet, "/organizations/:organization_id/profiles", env.getProfiles},
+		{http.MethodGet, "/organizations/:organization_id/transactions", env.getTransactions},
+		{http.MethodGet, "/organizations/:organization_id/projects/:project_id/functions_call_trees", env.getFunctionsCallTrees},
+		{http.MethodGet, "/organizations/:organization_id/projects/:project_id/functions_versions", env.getFunctions},
+		{http.MethodGet, "/organizations/:organization_id/projects/:project_id/profiles/:profile_id", env.getProfile},
+		{http.MethodGet, "/organizations/:organization_id/projects/:project_id/profiles/:profile_id/call_tree", env.getProfileCallTree},
+	}
+
 	router := httprouter.New()
 
-	router.Handler(http.MethodGet, "/organizations/:organization_id/filters", compress(http.HandlerFunc(env.getFilters)))
-	router.Handler(http.MethodGet, "/organizations/:organization_id/profiles", compress(http.HandlerFunc(env.getProfiles)))
-	router.Handler(http.MethodGet, "/organizations/:organization_id/transactions", compress(http.HandlerFunc(env.getTransactions)))
-	router.Handler(http.MethodGet, "/organizations/:organization_id/projects/:project_id/functions_call_trees", compress(http.HandlerFunc(env.getFunctionsCallTrees)))
-	router.Handler(http.MethodGet, "/organizations/:organization_id/projects/:project_id/functions_versions", compress(http.HandlerFunc(env.getFunctions)))
-	router.Handler(http.MethodGet, "/organizations/:organization_id/projects/:project_id/profiles/:profile_id", compress(http.HandlerFunc(env.getProfile)))
-	router.Handler(http.MethodGet, "/organizations/:organization_id/projects/:project_id/profiles/:profile_id/call_tree", compress(http.HandlerFunc(env.getProfileCallTree)))
+	for _, route := range routes {
+		router.Handler(route.method, route.path, compress(httputil.AnonymizeTransactionName(http.HandlerFunc(route.handler))))
+	}
 
 	return router, nil
 }


### PR DESCRIPTION
From seeing:
```
GET /organizations/324374/projects/6400379/functions_versions
```
To:
```
GET /organizations/:organization_id/projects/:project_id/functions_versions