### PR TITLE
fix(landing): Need to return project id with transactions

### DIFF
--- a/cmd/vroom/transaction.go
+++ b/cmd/vroom/transaction.go
@@ -22,6 +22,7 @@ type (
 		LastProfileAt time.Time           `json:"last_profile_at"`
 		Name          string              `json:"name"`
 		ProfilesCount int                 `json:"profiles_count"`
+		ProjectID     string              `json:"project_id"`
 		Versions      []string            `json:"versions"`
 	}
 
@@ -111,6 +112,7 @@ func snubaTransactionToTransaction(t snubautil.Transaction) Transaction {
 		LastProfileAt: t.LastProfileAt,
 		Name:          t.TransactionName,
 		ProfilesCount: t.ProfilesCount,
+		ProjectID:     strconv.FormatUint(t.ProjectID, 10),
 		Versions:      versions,
 	}
 }

--- a/internal/snubautil/transaction.go
+++ b/internal/snubautil/transaction.go
@@ -15,6 +15,7 @@ type (
 		DurationNS      []float64   `json:"duration_ns"`
 		LastProfileAt   time.Time   `json:"last_profile_at"`
 		ProfilesCount   int         `json:"profiles_count"`
+		ProjectID       uint64      `json:"project_id"`
 		TransactionName string      `json:"transaction_name"`
 		Versions        [][2]string `json:"versions"`
 	}
@@ -26,13 +27,14 @@ func GetTransactions(sqb QueryBuilder) ([]Transaction, error) {
 	defer rs.Finish()
 
 	sqb.SelectCols = []string{
+		"project_id",
 		"transaction_name",
 		"groupUniqArray(tuple(version_name, version_code)) AS versions",
 		"quantiles(0.5, 0.75, 0.9, 0.95, 0.99)(duration_ns) AS duration_ns",
 		"anyLast(received) AS last_profile_at",
 		"count() AS profiles_count",
 	}
-	sqb.GroupBy = "transaction_name"
+	sqb.GroupBy = "project_id, transaction_name"
 	sqb.OrderBy = "transaction_name ASC"
 
 	rb, err := sqb.Do(rs)


### PR DESCRIPTION
The transaction name alone is not sufficient. We need to return the project id
along side it in order to link to the appropriate pages.