### PR TITLE
Keep the main frame even if it's not symbolicated

### DIFF
--- a/internal/aggregate/backtrace.go
+++ b/internal/aggregate/backtrace.go
@@ -160,8 +160,8 @@ func (a *BacktraceAggregatorP) UpdateFromProfile(profile snubautil.Profile) erro
 			}
 			a.symbolsByProfileID[profile.ProfileID][frame.InstructionAddr] = symbol
 
-			if !isMainThread && frame.IsMain() {
-				isMainThread = true
+			if !isMainThread {
+				isMainThread, _ = frame.IsMain()
 			}
 		}
 		a.bta.Update(calltree.BacktraceP{

--- a/internal/aggregate/utils.go
+++ b/internal/aggregate/utils.go
@@ -264,8 +264,15 @@ type IosFrame struct {
 	Symbol          string `json:"symbol,omitempty"`
 }
 
-func (f IosFrame) IsMain() bool {
-	return f.Function == "main" || f.Function == "UIApplicationMain"
+// IsMain returns true if the function is considered the main function.
+// It also returns an offset indicate if we need to keep the previous frame or not.
+func (f IosFrame) IsMain() (bool, int) {
+	if f.Function == "main" {
+		return true, 0
+	} else if f.Function == "UIApplicationMain" {
+		return true, -1
+	}
+	return false, 0
 }
 
 type Sample struct {


### PR DESCRIPTION
Since we were cutting all frames above the main frame on the main thread since they are never symbolicated and not helpful, we had cases where `main`, in case we were missing application symbols, was cut.

This aims to fix this since we know `main` is the frame right before `UIApplicationMain`. In a profile not properly symbolicated (because of missing application symbols), we'll now understand we detected `UIApplicationMain` (a system symbol) and cut right to the frame above (hence keeping an unknown symbol we know is `main`).