### PR TITLE
fix(profiling): handle inline frames and fix isMainFrame

### DIFF
--- a/internal/aggregate/utils.go
+++ b/internal/aggregate/utils.go
@@ -310,10 +310,8 @@ type PythonProfile struct {
 func (f RustFrame) IsMain() bool {
 	if f.Status != "symbolicated" {
 		return false
-	} else if f.Function == "main" {
-		return true
 	}
-	return false
+	return strings.HasSuffix(f.Function, "::main")
 }
 
 // MainThread returns what we believe is the main thread ID in the profile


### PR DESCRIPTION
This PR includes several fixes:

1. `IsMain`: this will return true only for frames whose function has suffix `::main`, which is the main function of the package (usually it is <package_name::main>)
2. Everything that we were keeping before that main frame (`::main`) was "garbage" due to the profiler that should not be kept. It was sometimes present in some samples and sometimes missing in other samples, messing up with the `flamechart` final visualization so that is now removed
3.  previously we moved from using `instruction_address` to `sym_address` since in some cases the same function was captured with a different `lineno` and therefore a different `instruction_address` (see example snippet below). By using `sym_address` we're now correctly identifying the same frame (symbol) as it should be. For inline frames though, we don't have `sym_address` since the `Symbolicator`  services drops that field for inline frames. In this case we fall back on `instruction_address`, this way we're still able to show the frames for these functions. 

I've tested this both on the `fibonacci` and the `mandelbrot fractal renderer` and it finally works as expected.


Example of the same symbol with different `instruction_address` mentioned above:

```
                {
                    "status": "symbolicated",
                    "original_index": 1,
                    "instruction_addr": "0x1045194d8",
                    "package": "/Users/vigliasentry/Documents/git/rust-fractal-core/target/release/main",
                    "lang": "rust",
                    "symbol": "_ZN4main4main17h879f29ecdb3464eaE",
                    "sym_addr": "0x104518690",
                    "function": "main::main",
                    "filename": "main.rs",
                    "abs_path": "/Users/vigliasentry/Documents/git/rust-fractal-core/src/bin/main.rs",
                    "lineno": 78
                },

                {
                    "status": "symbolicated",
                    "original_index": 7,
                    "instruction_addr": "0x1045194e0",
                    "package": "/Users/vigliasentry/Documents/git/rust-fractal-core/target/release/main",
                    "lang": "rust",
                    "symbol": "_ZN4main4main17h879f29ecdb3464eaE",
                    "sym_addr": "0x104518690",
                    "function": "main::main",
                    "filename": "main.rs",
                    "abs_path": "/Users/vigliasentry/Documents/git/rust-fractal-core/src/bin/main.rs",
                    "lineno": 79
                },
```


