### PR TITLE
feat(chrometrace): Assign `main` to the main thread's thread_name

### DIFF
--- a/internal/chrometrace/snuba.go
+++ b/internal/chrometrace/snuba.go
@@ -403,7 +403,12 @@ func rustSpeedscopeTraceFromProfile(profile *aggregate.RustProfile) (output, err
 		if !ok {
 			threadName := sample.ThreadName
 			if threadName == "" {
-				threadName = threadID
+				if sample.ThreadID == mainThreadID {
+					threadName = "main"
+				} else {
+					threadName = threadID
+				}
+
 			}
 			sampProfile = &sampledProfile{
 				Name:         threadName,


### PR DESCRIPTION
When thread_name is empty but we succesfully identified the thread as the main one,
change is name to `main`.