### PR TITLE
feat: Add all profile metadata to the chrometrace output

### DIFF
--- a/cmd/vroom/profile.go
+++ b/cmd/vroom/profile.go
@@ -12,9 +12,12 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/getsentry/vroom/internal/aggregate"
 	"github.com/getsentry/vroom/internal/android"
+	"github.com/getsentry/vroom/internal/chrometrace"
 	"github.com/getsentry/vroom/internal/nodetree"
 	"github.com/getsentry/vroom/internal/snubautil"
 	"github.com/getsentry/vroom/internal/storageutil"
+	"github.com/google/uuid"
+	"github.com/julienschmidt/httprouter"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/api/googleapi"
 )
@@ -152,4 +155,157 @@ func getRawProfile(ctx context.Context,
 	}
 
 	return profile, nil
+}
+
+type RawProfile struct {
+	snubautil.Profile
+	ParsedProfile interface{} `json:"profile,omitempty"`
+}
+
+func (env *environment) getRawProfile(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	hub := sentry.GetHubFromContext(ctx)
+	ps := httprouter.ParamsFromContext(ctx)
+	rawOrganizationID := ps.ByName("organization_id")
+	organizationID, err := strconv.ParseUint(rawOrganizationID, 10, 64)
+	if err != nil {
+		hub.CaptureException(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	hub.Scope().SetTag("organization_id", rawOrganizationID)
+
+	rawProjectID := ps.ByName("project_id")
+	projectID, err := strconv.ParseUint(rawProjectID, 10, 64)
+	if err != nil {
+		sentry.CaptureException(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	hub.Scope().SetTag("project_id", rawProjectID)
+
+	profileID := ps.ByName("profile_id")
+	_, err = uuid.Parse(profileID)
+	if err != nil {
+		hub.CaptureException(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	hub.Scope().SetTag("profile_id", profileID)
+	s := sentry.StartSpan(ctx, "profile.read")
+	s.Description = "Read profile from GCS or Snuba"
+
+	profile, err := getRawProfile(ctx, organizationID, projectID, profileID, env.profilesBucket, env.snuba)
+	s.Finish()
+	if err != nil {
+		if errors.Is(err, snubautil.ErrProfileNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+
+	var parsedProfile interface{}
+	err = json.Unmarshal([]byte(profile.Profile), &parsedProfile)
+	if err != nil {
+		hub.CaptureException(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// set the original profile raw string to empty
+	// so that this field is not serialized
+	profile.Profile = ""
+
+	rawProfile := RawProfile{profile, parsedProfile}
+
+	s = sentry.StartSpan(ctx, "json.marshal")
+	defer s.Finish()
+	b, err := json.Marshal(rawProfile)
+	if err != nil {
+		hub.CaptureException(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600, immutable")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(b)
+}
+
+func (env *environment) getProfile(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	hub := sentry.GetHubFromContext(ctx)
+	ps := httprouter.ParamsFromContext(ctx)
+	rawOrganizationID := ps.ByName("organization_id")
+	organizationID, err := strconv.ParseUint(rawOrganizationID, 10, 64)
+	if err != nil {
+		hub.CaptureException(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	hub.Scope().SetTag("organization_id", rawOrganizationID)
+
+	rawProjectID := ps.ByName("project_id")
+	projectID, err := strconv.ParseUint(rawProjectID, 10, 64)
+	if err != nil {
+		sentry.CaptureException(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	hub.Scope().SetTag("project_id", rawProjectID)
+
+	profileID := ps.ByName("profile_id")
+	_, err = uuid.Parse(profileID)
+	if err != nil {
+		hub.CaptureException(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	hub.Scope().SetTag("profile_id", profileID)
+	s := sentry.StartSpan(ctx, "profile.read")
+	s.Description = "Read profile from GCS or Snuba"
+
+	profile, err := getRawProfile(ctx, organizationID, projectID, profileID, env.profilesBucket, env.snuba)
+	s.Finish()
+	if err != nil {
+		if errors.Is(err, snubautil.ErrProfileNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+	profile.DebugMeta = nil
+
+	hub.Scope().SetTag("platform", profile.Platform)
+
+	s = sentry.StartSpan(ctx, "json.marshal")
+	defer s.Finish()
+
+	var b []byte
+	switch profile.Platform {
+	case "typescript", "javascript":
+		b = []byte(profile.Profile)
+	default:
+		b, err = chrometrace.SpeedscopeFromSnuba(profile)
+	}
+	if err != nil {
+		hub.CaptureException(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600, immutable")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(b)
 }

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -1,5 +1,4 @@
 version: "3.9"
-name: vroom
 services:
   gcs:
     image: "fsouza/fake-gcs-server:latest"

--- a/internal/snubautil/profile.go
+++ b/internal/snubautil/profile.go
@@ -8,6 +8,7 @@ import (
 
 type Profile struct {
 	AndroidAPILevel      uint32      `json:"android_api_level,omitempty"`
+	DebugMeta            interface{} `json:"debug_meta,omitempty"`
 	DeviceClassification string      `json:"device_classification"`
 	DeviceLocale         string      `json:"device_locale"`
 	DeviceManufacturer   string      `json:"device_manufacturer"`
@@ -19,7 +20,6 @@ type Profile struct {
 	Environment          string      `json:"environment,omitempty"`
 	OrganizationID       uint64      `json:"organization_id"`
 	Platform             string      `json:"platform"`
-	DebugMeta            interface{} `json:"debug_meta,omitempty"`
 	Profile              string      `json:"profile,omitempty"`
 	ProfileID            string      `json:"profile_id"`
 	ProjectID            uint64      `json:"project_id"`


### PR DESCRIPTION
Add a metadata object to the chrometrace view with all profile metadata.
```
{
    "activeProfileIndex": 0,
    "androidClock": "Dual",
    "durationNS": 121293115,
    "metadata": {
        "androidAPILevel": 31,
        "deviceClassification": "high",
        "deviceLocale": "en_ZA",
        "deviceManufacturer": "samsung",
        "deviceModel": "SM-N975F",
        "deviceOSName": "android",
        "deviceOSVersion": "12",
        "durationNS": 121293115,
        "environment": "production_release",
        "organizationID": 413355,
        "platform": "android",
        "profileID": "d64c3bcb-8b36-4117-91f2-7667ad2772a7",
        "projectID": 5740063,
        "received": "2022-07-04T22:21:59Z",
        "traceID": "2a64dd57-b89b-4ea6-ab15-a48b03c8ff8d",
        "transactionID": "1a02e600-04fa-494d-810c-489febf09208",
        "transactionName": "TedPermissionActivity",
        "version": "1.28.4764 (1284764)"
    },
    "platform": "android",
    "profileID": "d64c3bcb-8b36-4117-91f2-7667ad2772a7",
    "profiles": [ ... ],
    "projectID": 5740063,
    "shared": { ... },
    "transactionName": "TedPermissionActivity",
    "version": "1.28.4764 (1284764)"
}
```