### PR TITLE
fix(profiling): Dont append version code if empty

### DIFF
--- a/internal/snubautil/version.go
+++ b/internal/snubautil/version.go
@@ -3,5 +3,8 @@ package snubautil
 import "fmt"
 
 func FormatVersion(name, code interface{}) string {
+	if code == "" {
+		return fmt.Sprintf("%v", name)
+	}
 	return fmt.Sprintf("%v (%v)", name, code)
 }


### PR DESCRIPTION
If the version code is empty, we should not append a pair of empty parens.