### PR TITLE
fix: Prevent a forever loop while unmarshaling sample profile

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -17,8 +17,6 @@ type (
 		Speedscope() (speedscope.Output, error)
 		CallTrees() (map[uint64][]*nodetree.Node, error)
 		StoragePath() string
-
-		UnmarshalJSON(b []byte) error
 	}
 
 	Profile struct {

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -1,7 +1,6 @@
 package sample
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -56,10 +55,6 @@ type (
 	}
 
 	SampleProfile struct {
-		sampleProfile
-	}
-
-	sampleProfile struct {
 		DebugMeta      interface{} `json:"debug_meta,omitempty"`
 		Device         Device      `json:"device"`
 		Environment    string      `json:"environment,omitempty"`
@@ -102,10 +97,6 @@ func (p SampleProfile) GetPlatform() string {
 
 func (p SampleProfile) CallTrees() (map[uint64][]*nodetree.Node, error) {
 	return make(map[uint64][]*nodetree.Node), nil
-}
-
-func (p *SampleProfile) UnmarshalJSON(b []byte) error {
-	return json.Unmarshal(b, &p.sampleProfile)
 }
 
 func (p *SampleProfile) Speedscope() (speedscope.Output, error) {


### PR DESCRIPTION
By calling `json.Unmarshal` on the same `struct` type, it will try to use the `UnmarshalJSON` of that `struct` as it's implementing the `Unmarshaler` interface and it will repeat itself forever.

We don't actually need `Profile` to implement the `Unmarshaler` interface, so we can remove it.