### PR TITLE
Fix IsApplicationPackage

### DIFF
--- a/internal/packageutil/package.go
+++ b/internal/packageutil/package.go
@@ -4,27 +4,31 @@ import "strings"
 
 // isApplicationSymbol determines whether the image represents that of the application
 // binary (or a binary embedded in the application binary) by checking its path.
-func IsRustApplicationPackage(image string) bool {
+func IsRustApplicationPackage(path string) bool {
 	// `/library/std/src/` and `/usr/lib/system/` come from a real profile collected on macos.
-	// In this case the function belongs to a shared library,
-	// not to the profiled application
-	return !strings.Contains(image, "/library/std/src/") &&
-		!strings.HasPrefix(image, "/usr/lib/system/") &&
-		!(image == "")
+	// In this case the function belongs to a shared library, not to the profiled application.
+	return !strings.Contains(path, "/library/std/src/") &&
+		!strings.HasPrefix(path, "/usr/lib/system/") &&
+		// the following a prefixes of functions belonging to either core lib
+		// or third party libs
+		!strings.HasPrefix(path, "/rustc/") &&
+		!strings.HasPrefix(path, "/usr/local/rustup/") &&
+		!strings.HasPrefix(path, "/usr/local/cargo/git/") &&
+		!(path == "")
 }
 
 // isApplicationSymbol determines whether the image represents that of the application
 // binary (or a binary embedded in the application binary) by checking its path.
-func IsIOSApplicationPackage(image string) bool {
+func IsIOSApplicationPackage(path string) bool {
 	// These are the path patterns that iOS uses for applications, system
 	// libraries are stored elsewhere.
 	//
 	// Must be kept in sync with the corresponding Python implementation of
 	// this function in python/symbolicate/__init__.py
-	return strings.HasPrefix(image, "/private/var/containers") ||
-		strings.HasPrefix(image, "/var/containers") ||
-		strings.Contains(image, "/Developer/Xcode/DerivedData") ||
-		strings.Contains(image, "/data/Containers/Bundle/Application")
+	return strings.HasPrefix(path, "/private/var/containers") ||
+		strings.HasPrefix(path, "/var/containers") ||
+		strings.Contains(path, "/Developer/Xcode/DerivedData") ||
+		strings.Contains(path, "/data/Containers/Bundle/Application")
 }
 
 var (

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -307,7 +307,7 @@ func (p *SampleProfile) Speedscope() (speedscope.Output, error) {
 				frames = append(frames, speedscope.Frame{
 					File:          fr.File,
 					Image:         fr.PackageBaseName(),
-					IsApplication: p.IsApplicationPackage(fr.PackageBaseName()),
+					IsApplication: p.IsApplicationPackage(fr.Path),
 					Line:          fr.Line,
 					Name:          symbolName,
 				})
@@ -383,12 +383,12 @@ func (p *SampleProfile) Raw() []byte {
 	return []byte{}
 }
 
-func (p *SampleProfile) IsApplicationPackage(pkg string) bool {
+func (p *SampleProfile) IsApplicationPackage(path string) bool {
 	switch p.Platform {
 	case "cocoa":
-		return packageutil.IsIOSApplicationPackage(pkg)
+		return packageutil.IsIOSApplicationPackage(path)
 	case "rust":
-		return packageutil.IsRustApplicationPackage(pkg)
+		return packageutil.IsRustApplicationPackage(path)
 	}
 	return true
 }


### PR DESCRIPTION
This should affect both `Rust` and `iOS`.

At the moment we are passing the `PackageBaseName` instead of the `path`. 
The actual checks should be done against the path though. As a result we're not able to see different colouring in the `flamechart`.