### PR TITLE
fix: frame for each inlines

### DIFF
--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -133,7 +133,7 @@ func (f Frame) ID() string {
 	// and gets the wrong line number
 	//
 	// Also, when a frame is symbolicated but is missing the symbol_address
-	// we know we're dealing with inlines, but we can't relt on instruction_address
+	// we know we're dealing with inlines, but we can't rely on instruction_address
 	// neither as the inlines are all using the same one. If we were to return this
 	// address in speedscope we would only generate a new frame for the parent one
 	// and for the inlines we would show the same information of the parents instead


### PR DESCRIPTION
**Context**

When a frame is symbolicated (function name, lines, etc.) but it's missing `symbol_address`, we know it's an inlines (that's what _symbolicator_ does).

**Problem**

Since in the speedscope we need an address (we map from addresses to frames) we solved that issue by using `instruction_address` when `symbol_address` is not available.

The problem with that is that inlines all have the same `instruction_address` so we would end up returning the same address which means we won't create a new frame as that address already exists in the map and as a result for each inline we would keep showing the parent frame as showed here below

<img width="1125" alt="Screenshot 2022-11-04 at 14 41 12" src="https://user-images.githubusercontent.com/5112977/199988051-220ca688-fa73-4bd1-b427-c1fa14066612.png">


As a solution (to get unique "addresses") I propose a slight variation of the `hash` function we are already using when there are no `symbol_address` or `instruction_address`.

`hash := md5.Sum([]byte(fmt.Sprintf("%s:%s:%d:%s", f.File, f.Function, f.Line, f.InstructionAddr)))`

In fairness ` f.File, f.Function, f.Line` would be enough, but I've noticed that if the user only upload the `debug` file and not the `Bundle Source` the line might not be available so I'd rather have the `instruction_address` too.

With this fix you can see that the 3 previous `inlines` which were all showing as `std::panicking:try` are now correctly visualized.

<img width="577" alt="Screenshot 2022-11-04 at 14 42 31" src="https://user-images.githubusercontent.com/5112977/199989136-04a2b5a8-ba82-455d-b4a5-81bda2a750cf.png">


**PS.: This affects not only Rust but iOS too**
