### PR TITLE
Fix third party path check for Rust

### DIFF
--- a/internal/packageutil/package.go
+++ b/internal/packageutil/package.go
@@ -13,7 +13,7 @@ func IsRustApplicationPackage(path string) bool {
 		// or third party libs
 		!strings.HasPrefix(path, "/rustc/") &&
 		!strings.HasPrefix(path, "/usr/local/rustup/") &&
-		!strings.HasPrefix(path, "/usr/local/cargo/git/") &&
+		!strings.HasPrefix(path, "/usr/local/cargo/") &&
 		!(path == "")
 }
 


### PR DESCRIPTION
Include as third party lib everything under `/usr/local/cargo` (bot git and registry)