### PR TITLE
fix: Set package as not in application by default for Python and Node

### DIFF
--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -392,7 +392,7 @@ func (p *SampleProfile) IsApplicationFrame(f Frame) bool {
 		return *f.InApp
 	}
 	if p.Platform == "node" {
-		return strings.Contains("/node_modules/", f.Path) || strings.HasPrefix("native", f.Symbol)
+		return strings.Contains("node_modules", f.Path)
 	}
 	return p.IsApplicationPackage(f.Path)
 }


### PR DESCRIPTION
We receive an `in_app` field from the Python SDK to say if the frame is from the application or not, and if we don't receive anything, we fallback to the package logic. It defaults to "in application" by default and we want to override that for Python.