### PR TITLE
feat: support p95 sorts on functions endpoint

### DIFF
--- a/cmd/vroom/functions.go
+++ b/cmd/vroom/functions.go
@@ -73,7 +73,7 @@ func (env *environment) getFunctions(w http.ResponseWriter, r *http.Request) {
 		direction = "DESC"
 		rawOrderBy = strings.TrimPrefix(rawOrderBy, "-")
 	}
-	if rawOrderBy != "p75" && rawOrderBy != "p99" && rawOrderBy != "count" {
+	if rawOrderBy != "p75" && rawOrderBy != "p99" && rawOrderBy != "p95" && rawOrderBy != "count" {
 		hub.CaptureException(fmt.Errorf("unknown sort: %s", rawOrderBy))
 		w.WriteHeader(http.StatusBadRequest)
 		return


### PR DESCRIPTION
### Summary
Attempting to sort by `p95` throws a 500 even though its a column we return. This PR adds the ability to sort by `p95`.