### PR TITLE
Revert "chore: Send occurrences for a new org"

### DIFF
--- a/cmd/vroom/config.go
+++ b/cmd/vroom/config.go
@@ -28,7 +28,6 @@ var (
 			OccurrencesEnabledOrganizations: map[uint64]struct{}{
 				1:      {},
 				447951: {},
-				77029:  {},
 			},
 			OccurrencesKafkaTopic:   "ingest-occurrences",
 			OccurrencesKafkaBrokers: []string{"192.168.142.19:9092", "192.168.142.20:9092", "192.168.142.21:9092"},


### PR DESCRIPTION
Reverts getsentry/vroom#154

Turns out notifications for issues are not being a feature flag yet so the organization would see these and we don't want that.