### PR TITLE
chore: Use proper values for Snuba and Profiling broker

### DIFF
--- a/cmd/vroom/config.go
+++ b/cmd/vroom/config.go
@@ -24,14 +24,14 @@ var (
 		"production": {
 			SentryDSN:      "https://91f2762536314cbd9cc4a163fe072682@o1.ingest.sentry.io/6424467",
 			ProfilesBucket: "sentry-profiles",
-			SnubaHost:      "http://10.2.0.175",
+			SnubaHost:      "http://127.0.0.1:10006",
 			OccurrencesEnabledOrganizations: map[uint64]struct{}{
 				1:      {},
 				447951: {},
 			},
 			OccurrencesKafkaTopic:   "ingest-occurrences",
 			OccurrencesKafkaBrokers: []string{"kafka-issue-platform.service.us-central1.consul:9092"},
-			ProfilingKafkaBrokers:   []string{"192.168.142.19:9092", "192.168.142.20:9092", "192.168.142.21:9092"},
+			ProfilingKafkaBrokers:   []string{"specto-dev-kafka.service.us-central1.consul:9092"},
 			CallTreesKafkaTopic:     "profiles-call-tree",
 			ProfilesKafkaTopic:      "processed-profiles",
 		},


### PR DESCRIPTION
This will use the right discovery mechanisms for both services instead of hardcoded IPs.