### PR TITLE
enhancement: Update commit hooks to new project.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,5 +4,5 @@ repos:
   hooks:
     - id: go-build-repo-mod
     - id: go-imports
-    - id: go-mod-tidy
+    - id: go-mod-tidy-repo
     - id: golangci-lint-repo-mod


### PR DESCRIPTION
The `dnephin` project that we're currently using, according to the owner, is going to be sunset soon.

ps. using release `v1.0.0-rc.1` instead of `v0.8.3` because of the `go-mod-tidy` not being available in the latter one.