### PR TITLE
fix: Use a more robust way to check the type

### DIFF
--- a/internal/profile/legacy.go
+++ b/internal/profile/legacy.go
@@ -108,7 +108,7 @@ func (p *LegacyProfile) UnmarshalJSON(b []byte) error {
 		if err != nil {
 			return err
 		}
-		p.Trace = t
+		p.Trace = &t
 		p.Profile = nil
 	case "android":
 		var t Android
@@ -116,7 +116,7 @@ func (p *LegacyProfile) UnmarshalJSON(b []byte) error {
 		if err != nil {
 			return err
 		}
-		p.Trace = t
+		p.Trace = &t
 		p.Profile = nil
 	default:
 		return errors.New("unknown platform")
@@ -204,8 +204,9 @@ func (p LegacyProfile) GetReceived() time.Time {
 }
 
 func (p *LegacyProfile) Normalize() {
-	if p.Platform == platform.Cocoa {
-		p.Trace.(*IOS).ReplaceIdleStacks()
+	switch t := p.Trace.(type) {
+	case *IOS:
+		t.ReplaceIdleStacks()
 	}
 }
 


### PR DESCRIPTION
Before, the `platform` value was wrong and the condition was never matched. I fixed it in a recent commit but now, the interface type wasn't right (https://github.com/getsentry/vroom/commit/e34033faf87322cd7577f031437454ef7dafcb5b#diff-06531bdea916c131efd314610138f1b4f977975efb4bcfacfb06b52337a96866R207)

This use the type of the value of the interface instead of relying on the platform and fix the value of the interface.