### PR TITLE
feat: add projectID to flamegraph

### DIFF
--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -108,7 +108,7 @@ func GetFlamegraphFromProfiles(
 		countProfAggregated++
 	}
 
-	sp := toSpeedscope(flamegraphTree, 4)
+	sp := toSpeedscope(flamegraphTree, 4, projectID)
 	hub.Scope().SetTag("processed_profiles", strconv.Itoa(countProfAggregated))
 	return sp, nil
 }
@@ -182,7 +182,7 @@ type flamegraph struct {
 	minFreq           int
 }
 
-func toSpeedscope(trees []*nodetree.Node, minFreq int) speedscope.Output {
+func toSpeedscope(trees []*nodetree.Node, minFreq int, projectID uint64) speedscope.Output {
 	fd := &flamegraph{
 		frames:           make([]speedscope.Frame, 0),
 		framesIndex:      make(map[string]int),
@@ -208,6 +208,11 @@ func toSpeedscope(trees []*nodetree.Node, minFreq int) speedscope.Output {
 	}
 
 	return speedscope.Output{
+		Metadata: speedscope.ProfileMetadata{
+			ProfileView: speedscope.ProfileView{
+				ProjectID: projectID,
+			},
+		},
 		Shared: speedscope.SharedData{
 			Frames:     fd.frames,
 			ProfileIDs: fd.profilesIDs,

--- a/internal/flamegraph/flamegraph_test.go
+++ b/internal/flamegraph/flamegraph_test.go
@@ -120,6 +120,11 @@ func TestFlamegraphAggregation(t *testing.T) {
 				}, // end prof definition
 			},
 			output: speedscope.Output{
+				Metadata: speedscope.ProfileMetadata{
+					ProfileView: speedscope.ProfileView{
+						ProjectID: 99,
+					},
+				},
 				Profiles: []interface{}{
 					speedscope.SampledProfile{
 						EndValue:     7,
@@ -192,7 +197,7 @@ func TestFlamegraphAggregation(t *testing.T) {
 				addCallTreeToFlamegraph(&ft, callTrees[0], p.ID())
 			}
 
-			if diff := testutil.Diff(toSpeedscope(ft, 1), test.output, options); diff != "" {
+			if diff := testutil.Diff(toSpeedscope(ft, 1, 99), test.output, options); diff != "" {
 				t.Fatalf("Result mismatch: got - want +\n%s", diff)
 			}
 		})


### PR DESCRIPTION
## Summary
Some of the inner workings of our flamegraph components depend on the profile metadata, specifically the `projectID`. I realize we can't handle all the attributes since we're dealing with an aggregate