### PR TITLE
ref: Drop profile is the Kafka messages produced are too big

### DIFF
--- a/cmd/vroom/profile.go
+++ b/cmd/vroom/profile.go
@@ -164,6 +164,9 @@ func (env *environment) postProfile(w http.ResponseWriter, r *http.Request) {
 			Value: b,
 		})
 		s.Finish()
+		hub.Scope().SetContext("Call trees Kakfa payload", map[string]interface{}{
+			"Size": len(b),
+		})
 		if err != nil {
 			hub.CaptureException(err)
 		}
@@ -187,6 +190,9 @@ func (env *environment) postProfile(w http.ResponseWriter, r *http.Request) {
 		Value: b,
 	})
 	s.Finish()
+	hub.Scope().SetContext("Profile metadata Kafka payload", map[string]interface{}{
+		"Size": len(b),
+	})
 	if err != nil {
 		hub.CaptureException(err)
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
This will drop the profile if the Kafka messages we're trying to produce are too big.

We'll also add to the context of the transaction the size of the profile we processed.