### PR TITLE
fix(profiling): Do not update package on any platform

### DIFF
--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -238,7 +238,7 @@ func (f *flamegraph) visitCalltree(node *nodetree.Node, currentStack *[]int) {
 		frame := node.ToFrame()
 		sfr := speedscope.Frame{
 			Name:          frame.Function,
-			Image:         frame.Package,
+			Image:         frame.PackageBaseName(),
 			Path:          frame.Path,
 			IsApplication: *frame.InApp,
 			Col:           frame.Column,

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -238,7 +238,7 @@ func (f *flamegraph) visitCalltree(node *nodetree.Node, currentStack *[]int) {
 		frame := node.ToFrame()
 		sfr := speedscope.Frame{
 			Name:          frame.Function,
-			Image:         frame.PackageBaseName(),
+			Image:         frame.ModuleOrPackage(),
 			Path:          frame.Path,
 			IsApplication: *frame.InApp,
 			Col:           frame.Column,

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -83,7 +83,9 @@ func (f Frame) PackageBaseName() string {
 
 func (f Frame) WriteToHash(h hash.Hash) {
 	var s string
-	if f.Package != "" {
+	if f.Module != "" {
+		s = f.Module
+	} else if f.Package != "" {
 		s = f.PackageBaseName()
 	} else if f.File != "" {
 		s = f.File

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -72,13 +72,11 @@ func (f Frame) ID() string {
 	return hex.EncodeToString(hash[:])
 }
 
-func (f Frame) PackageBaseName() string {
+func (f Frame) ModuleOrPackage() string {
 	if f.Module != "" {
 		return f.Module
-	} else if f.Package != "" {
-		return path.Base(f.Package)
 	}
-	return ""
+	return f.Package
 }
 
 func (f Frame) WriteToHash(h hash.Hash) {
@@ -86,7 +84,7 @@ func (f Frame) WriteToHash(h hash.Hash) {
 	if f.Module != "" {
 		s = f.Module
 	} else if f.Package != "" {
-		s = f.PackageBaseName()
+		s = path.Base(f.Package)
 	} else if f.File != "" {
 		s = f.File
 	} else {

--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -56,7 +56,6 @@ func (n *Node) Update(timestamp uint64) {
 
 func (n *Node) ToFrame() frame.Frame {
 	n.Frame.Data.SymbolicatorStatus = n.Frame.Status
-	n.Frame.Package = n.Frame.ModuleOrPackage()
 	return n.Frame
 }
 

--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -37,7 +37,7 @@ func NodeFromFrame(f frame.Frame, start, end, fingerprint uint64) *Node {
 		IsApplication: inApp,
 		Line:          f.Line,
 		Name:          f.Function,
-		Package:       f.PackageBaseName(),
+		Package:       f.ModuleOrPackage(),
 		Path:          f.Path,
 		SampleCount:   1,
 		StartNS:       start,
@@ -56,7 +56,7 @@ func (n *Node) Update(timestamp uint64) {
 
 func (n *Node) ToFrame() frame.Frame {
 	n.Frame.Data.SymbolicatorStatus = n.Frame.Status
-	n.Frame.Package = n.Frame.PackageBaseName()
+	n.Frame.Package = n.Frame.ModuleOrPackage()
 	return n.Frame
 }
 

--- a/internal/nodetree/nodetree_test.go
+++ b/internal/nodetree/nodetree_test.go
@@ -1,11 +1,8 @@
 package nodetree
 
 import (
-	"encoding/json"
-	"strings"
 	"testing"
 
-	"github.com/getsentry/vroom/internal/frame"
 	"github.com/getsentry/vroom/internal/testutil"
 )
 
@@ -658,25 +655,5 @@ func TestNodeTreeCollapse(t *testing.T) {
 				t.Fatalf("Result mismatch: got - want +\n%s", diff)
 			}
 		})
-	}
-}
-
-func TestFramePackageName(t *testing.T) {
-	var f frame.Frame
-	err := json.Unmarshal([]byte(`{
-		"function": "_dispatch_event_loop_leave_immediate",
-		"in_app": false,
-		"instruction_addr": "0x1c44cfe34",
-		"package": "/usr/lib/system/libdispatch.dylib",
-		"status": "symbolicated",
-		"sym_addr": "0x1c44cfd60",
-		"symbol": "_dispatch_event_loop_leave_immediate"
-	}`), &f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	n := NodeFromFrame(f, 0, 0, 1234567890)
-	if strings.HasPrefix(n.Package, "/") || n.Package != f.PackageBaseName() {
-		t.Fatal("package name should not be a path")
 	}
 }

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -308,7 +308,7 @@ func (p *Profile) Speedscope() (speedscope.Output, error) {
 					// image exists for legacy reasons as a field coalesced from module and package
 					// the speedscope transform on the sampled format is being removed, so leave
 					// it alone for now
-					Image:         fr.PackageBaseName(),
+					Image:         fr.ModuleOrPackage(),
 					Inline:        fr.IsInline(),
 					IsApplication: p.IsApplicationFrame(fr),
 					Line:          fr.Line,
@@ -553,16 +553,6 @@ func (p *Profile) normalizeFrames() {
 		// Set if frame is in application
 		inApp := p.IsApplicationFrame(f)
 		f.InApp = &inApp
-
-		// Transform package path into a name
-		switch p.Platform {
-		case platform.Cocoa:
-			f.Package = f.PackageBaseName()
-		case platform.Rust:
-			f.Package = f.PackageBaseName()
-		default:
-			// do nothing since the other platforms do not use package
-		}
 
 		// Set Symbolicator status
 		if f.Status != "" {

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -303,8 +303,11 @@ func (p *Profile) Speedscope() (speedscope.Output, error) {
 				}
 				addressToFrameIndex[address] = frameIndex
 				frames = append(frames, speedscope.Frame{
-					Col:           fr.Column,
-					File:          fr.File,
+					Col:  fr.Column,
+					File: fr.File,
+					// image exists for legacy reasons as a field coalesced from module and package
+					// the speedscope transform on the sampled format is being removed, so leave
+					// it alone for now
 					Image:         fr.PackageBaseName(),
 					Inline:        fr.IsInline(),
 					IsApplication: p.IsApplicationFrame(fr),
@@ -552,7 +555,14 @@ func (p *Profile) normalizeFrames() {
 		f.InApp = &inApp
 
 		// Transform package path into a name
-		f.Package = f.PackageBaseName()
+		switch p.Platform {
+		case platform.Cocoa:
+			f.Package = f.PackageBaseName()
+		case platform.Rust:
+			f.Package = f.PackageBaseName()
+		default:
+			// do nothing since the other platforms do not use package
+		}
 
 		// Set Symbolicator status
 		if f.Status != "" {

--- a/internal/sample/sample_test.go
+++ b/internal/sample/sample_test.go
@@ -897,7 +897,7 @@ func TestNormalizeFramesPerPlatform(t *testing.T) {
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "main",
-								Package:  "foo", // the package gets normalize to just the basename
+								Package:  "/private/var/containers/foo",
 								InApp:    &testutil.True,
 							},
 						},
@@ -935,7 +935,7 @@ func TestNormalizeFramesPerPlatform(t *testing.T) {
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "main",
-								Package:  "foo", // the package gets normalize to just the basename
+								Package:  "/usr/local/foo",
 								InApp:    &testutil.True,
 							},
 						},
@@ -1036,13 +1036,13 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 						Fingerprint:   1628006971372193492,
 						IsApplication: true,
 						Name:          "main",
-						Package:       "foo",
+						Package:       "/private/var/containers/foo",
 						SampleCount:   1,
 						ProfileIDs:    map[string]struct{}{},
 						Frame: frame.Frame{
 							Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 							Function: "main",
-							Package:  "foo",
+							Package:  "/private/var/containers/foo",
 							InApp:    &testutil.True,
 						},
 					},
@@ -1081,13 +1081,13 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 						Fingerprint:   1628006971372193492,
 						IsApplication: true,
 						Name:          "main",
-						Package:       "foo",
+						Package:       "/usr/local/foo",
 						SampleCount:   1,
 						ProfileIDs:    map[string]struct{}{},
 						Frame: frame.Frame{
 							Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 							Function: "main",
-							Package:  "foo",
+							Package:  "/usr/local/foo",
 							InApp:    &testutil.True,
 						},
 					},

--- a/internal/sample/sample_test.go
+++ b/internal/sample/sample_test.go
@@ -863,3 +863,297 @@ func TestTrimCocoaStacks(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeFramesPerPlatform(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  Profile
+		output Profile
+	}{
+		{
+			name: "cocoa",
+			input: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.Cocoa,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
+								Function: "main",
+								Package:  "/private/var/containers/foo",
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+					},
+				},
+			},
+			output: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.Cocoa,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
+								Function: "main",
+								Package:  "foo", // the package gets normalize to just the basename
+								InApp:    &testutil.True,
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rust",
+			input: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.Rust,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
+								Function: "main",
+								Package:  "/usr/local/foo",
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+					},
+				},
+			},
+			output: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.Rust,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
+								Function: "main",
+								Package:  "foo", // the package gets normalize to just the basename
+								InApp:    &testutil.True,
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "python",
+			input: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.Python,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Function: "Threading.run",
+								File:     "threading.py",
+								Module:   "threading",
+								Path:     "/usr/local/lib/python3.8/threading.py",
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+					},
+				},
+			},
+			output: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.Python,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Function: "Threading.run",
+								File:     "threading.py",
+								Module:   "threading",
+								Path:     "/usr/local/lib/python3.8/threading.py",
+								InApp:    &testutil.False,
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.input.Normalize()
+			if diff := testutil.Diff(test.input, test.output); diff != "" {
+				t.Fatalf("Result mismatch: got - want +\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCallTreesFingerprintPerPlatform(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  Profile
+		output map[uint64][]*nodetree.Node
+	}{
+		{
+			name: "cocoa",
+			input: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.Cocoa,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
+								Function: "main",
+								Package:  "/private/var/containers/foo",
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+						Samples: []Sample{
+							{
+								ElapsedSinceStartNS: 0,
+								StackID:             0,
+								ThreadID:            0,
+							},
+						},
+					},
+				},
+			},
+			output: map[uint64][]*nodetree.Node{
+				0: {
+					{
+						Fingerprint:   1628006971372193492,
+						IsApplication: true,
+						Name:          "main",
+						Package:       "foo",
+						SampleCount:   1,
+						ProfileIDs:    map[string]struct{}{},
+						Frame: frame.Frame{
+							Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
+							Function: "main",
+							Package:  "foo",
+							InApp:    &testutil.True,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rust",
+			input: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.Rust,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
+								Function: "main",
+								Package:  "/usr/local/foo",
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+						Samples: []Sample{
+							{
+								ElapsedSinceStartNS: 0,
+								StackID:             0,
+								ThreadID:            0,
+							},
+						},
+					},
+				},
+			},
+			output: map[uint64][]*nodetree.Node{
+				0: {
+					{
+						Fingerprint:   1628006971372193492,
+						IsApplication: true,
+						Name:          "main",
+						Package:       "foo",
+						SampleCount:   1,
+						ProfileIDs:    map[string]struct{}{},
+						Frame: frame.Frame{
+							Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
+							Function: "main",
+							Package:  "foo",
+							InApp:    &testutil.True,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "python",
+			input: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.Python,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Function: "Threading.run",
+								File:     "threading.py",
+								Module:   "threading",
+								Path:     "/usr/local/lib/python3.8/threading.py",
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+						Samples: []Sample{
+							{
+								ElapsedSinceStartNS: 0,
+								StackID:             0,
+								ThreadID:            0,
+							},
+						},
+					},
+				},
+			},
+			output: map[uint64][]*nodetree.Node{
+				0: {
+					{
+						Fingerprint:   12857020554704472368,
+						IsApplication: false,
+						Name:          "Threading.run",
+						Package:       "threading",
+						Path:          "/usr/local/lib/python3.8/threading.py",
+						SampleCount:   1,
+						ProfileIDs:    map[string]struct{}{},
+						Frame: frame.Frame{
+							Function: "Threading.run",
+							File:     "threading.py",
+							Module:   "threading",
+							InApp:    &testutil.False,
+							Path:     "/usr/local/lib/python3.8/threading.py",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.input.Normalize()
+			callTrees, err := test.input.CallTrees()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := testutil.Diff(callTrees, test.output); diff != "" {
+				t.Fatalf("Result mismatch: got - want +\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Package should only be used for native platforms like cocoa and rust. This only updates it on the frame and not the nodetree because the nodetree is serialized for the suspect functions feature which coalesces module and package together still so that is left untouched. This also ensures that the frame fingerprint does not change.