### PR TITLE
fix: Close remaining open frames for Android call trees

### DIFF
--- a/internal/profile/ios.go
+++ b/internal/profile/ios.go
@@ -421,3 +421,10 @@ func (p IOS) Speedscope() (speedscope.Output, error) {
 		Shared:             speedscope.SharedData{Frames: frames},
 	}, nil
 }
+
+func (p IOS) DurationNS() uint64 {
+	if len(p.Samples) == 0 {
+		return 0
+	}
+	return p.Samples[len(p.Samples)-1].RelativeTimestampNS - p.Samples[0].RelativeTimestampNS
+}

--- a/internal/profile/legacy.go
+++ b/internal/profile/legacy.go
@@ -244,5 +244,5 @@ func (p LegacyProfile) GetRetentionDays() int {
 }
 
 func (p LegacyProfile) GetDurationNS() uint64 {
-	return p.DurationNS
+	return p.Trace.DurationNS()
 }

--- a/internal/profile/trace.go
+++ b/internal/profile/trace.go
@@ -9,6 +9,7 @@ type (
 	Trace interface {
 		ActiveThreadID() uint64
 		CallTrees() map[uint64][]*nodetree.Node
+		DurationNS() uint64
 		Speedscope() (speedscope.Output, error)
 	}
 )


### PR DESCRIPTION
This also fixes the duration of the profile by calculating the delta between last and first event.