### PR TITLE
fix: avoid nil pointer dereference

### DIFF
--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -240,7 +240,7 @@ func (f *flamegraph) visitCalltree(node *nodetree.Node, currentStack *[]int) {
 			Name:          frame.Function,
 			Image:         frame.ModuleOrPackage(),
 			Path:          frame.Path,
-			IsApplication: *frame.InApp,
+			IsApplication: node.IsApplication,
 			Col:           frame.Column,
 			File:          frame.File,
 			Inline:        frame.IsInline(),


### PR DESCRIPTION
Fixes nil pointer dereference when setting IsApplication field in Flamegraph's `visitCalltree` method.
