### PR TITLE
feat: Add transaction metadata and tags to the profile

### DIFF
--- a/internal/occurrence/occurrence.go
+++ b/internal/occurrence/occurrence.go
@@ -178,7 +178,6 @@ func NewOccurrence(p profile.Profile, ni nodeInfo) *Occurrence {
 	_, _ = io.WriteString(h, ni.Node.Frame.ModuleOrPackage())
 	_, _ = io.WriteString(h, ni.Node.Name)
 	fingerprint := fmt.Sprintf("%x", h.Sum(nil))
-	tags := buildOccurrenceTags(p)
 	return &Occurrence{
 		Culprit:       t.Name,
 		DetectionTime: time.Now().UTC(),
@@ -192,7 +191,7 @@ func NewOccurrence(p profile.Profile, ni nodeInfo) *Occurrence {
 			Received:       p.Received(),
 			Release:        p.Release(),
 			StackTrace:     StackTrace{Frames: ni.StackTrace},
-			Tags:           tags,
+			Tags:           p.TransactionTags(),
 			Timestamp:      p.Timestamp(),
 		},
 		EvidenceData: evidenceData,
@@ -223,24 +222,6 @@ func NewOccurrence(p profile.Profile, ni nodeInfo) *Occurrence {
 		durationNS:  ni.Node.DurationNS,
 		sampleCount: ni.Node.SampleCount,
 	}
-}
-
-func buildOccurrenceTags(p profile.Profile) map[string]string {
-	pm := p.Metadata()
-	tags := map[string]string{
-		"device_classification": pm.DeviceClassification,
-		"device_locale":         pm.DeviceLocale,
-		"device_manufacturer":   pm.DeviceManufacturer,
-		"device_model":          pm.DeviceModel,
-		"device_os_name":        pm.DeviceOSName,
-		"device_os_version":     pm.DeviceOSVersion,
-	}
-
-	if pm.DeviceOSBuildNumber != "" {
-		tags["device_os_build_number"] = pm.DeviceOSBuildNumber
-	}
-
-	return tags
 }
 
 func (o *Occurrence) Link() (string, error) {

--- a/internal/profile/legacy.go
+++ b/internal/profile/legacy.go
@@ -51,7 +51,9 @@ type (
 		RetentionDays        int                                 `json:"retention_days"`
 		TraceID              string                              `json:"trace_id"`
 		TransactionID        string                              `json:"transaction_id"`
+		TransactionMetadata  transaction.Metadata                `json:"transaction_metadata"`
 		TransactionName      string                              `json:"transaction_name"`
+		TransactionTags      map[string]string                   `json:"transaction_tags,omitempty"`
 		VersionCode          string                              `json:"version_code"`
 		VersionName          string                              `json:"version_name"`
 	}
@@ -245,4 +247,12 @@ func (p LegacyProfile) GetRetentionDays() int {
 
 func (p LegacyProfile) GetDurationNS() uint64 {
 	return p.Trace.DurationNS()
+}
+
+func (p LegacyProfile) GetTransactionMetadata() transaction.Metadata {
+	return p.TransactionMetadata
+}
+
+func (p LegacyProfile) GetTransactionTags() map[string]string {
+	return p.TransactionTags
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -27,6 +27,8 @@ type (
 		GetRetentionDays() int
 		GetTimestamp() time.Time
 		GetTransaction() transaction.Transaction
+		GetTransactionMetadata() transaction.Metadata
+		GetTransactionTags() map[string]string
 
 		CallTrees() (map[uint64][]*nodetree.Node, error)
 		IsSampleFormat() bool
@@ -140,4 +142,12 @@ func (p *Profile) RetentionDays() int {
 
 func (p *Profile) DurationNS() uint64 {
 	return p.profile.GetDurationNS()
+}
+
+func (p *Profile) TransactionMetadata() transaction.Metadata {
+	return p.profile.GetTransactionMetadata()
+}
+
+func (p *Profile) TransactionTags() map[string]string {
+	return p.profile.GetTransactionTags()
 }

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -72,24 +72,26 @@ type (
 	}
 
 	RawProfile struct {
-		DebugMeta      debugmeta.DebugMeta                 `json:"debug_meta"`
-		Device         Device                              `json:"device"`
-		Environment    string                              `json:"environment,omitempty"`
-		EventID        string                              `json:"event_id"`
-		Measurements   map[string]measurements.Measurement `json:"measurements,omitempty"`
-		OS             OS                                  `json:"os"`
-		OrganizationID uint64                              `json:"organization_id"`
-		Platform       platform.Platform                   `json:"platform"`
-		ProjectID      uint64                              `json:"project_id"`
-		Received       timeutil.Time                       `json:"received"`
-		Release        string                              `json:"release"`
-		RetentionDays  int                                 `json:"retention_days"`
-		Runtime        Runtime                             `json:"runtime"`
-		Timestamp      time.Time                           `json:"timestamp"`
-		Trace          Trace                               `json:"profile"`
-		Transaction    transaction.Transaction             `json:"transaction"`
-		Transactions   []transaction.Transaction           `json:"transactions,omitempty"`
-		Version        string                              `json:"version"`
+		DebugMeta           debugmeta.DebugMeta                 `json:"debug_meta"`
+		Device              Device                              `json:"device"`
+		Environment         string                              `json:"environment,omitempty"`
+		EventID             string                              `json:"event_id"`
+		Measurements        map[string]measurements.Measurement `json:"measurements,omitempty"`
+		OS                  OS                                  `json:"os"`
+		OrganizationID      uint64                              `json:"organization_id"`
+		Platform            platform.Platform                   `json:"platform"`
+		ProjectID           uint64                              `json:"project_id"`
+		Received            timeutil.Time                       `json:"received"`
+		Release             string                              `json:"release"`
+		RetentionDays       int                                 `json:"retention_days"`
+		Runtime             Runtime                             `json:"runtime"`
+		Timestamp           time.Time                           `json:"timestamp"`
+		Trace               Trace                               `json:"profile"`
+		Transaction         transaction.Transaction             `json:"transaction"`
+		TransactionMetadata transaction.Metadata                `json:"transaction_metadata,omitempty"`
+		TransactionTags     map[string]string                   `json:"transaction_tags,omitempty"`
+		Transactions        []transaction.Transaction           `json:"transactions,omitempty"`
+		Version             string                              `json:"version"`
 	}
 
 	State string
@@ -614,4 +616,12 @@ func (t *Trace) trimCocoaStacks() {
 		}
 		t.Stacks[si] = t.Stacks[si][:ci]
 	}
+}
+
+func (p RawProfile) GetTransactionMetadata() transaction.Metadata {
+	return p.TransactionMetadata
+}
+
+func (p RawProfile) GetTransactionTags() map[string]string {
+	return p.TransactionTags
 }

--- a/internal/speedscope/speedscope.go
+++ b/internal/speedscope/speedscope.go
@@ -7,6 +7,7 @@ import (
 	"github.com/getsentry/vroom/internal/measurements"
 	"github.com/getsentry/vroom/internal/platform"
 	"github.com/getsentry/vroom/internal/timeutil"
+	"github.com/getsentry/vroom/internal/transaction"
 )
 
 const (
@@ -126,7 +127,9 @@ type (
 		RetentionDays        int                                 `json:"-"`                             //nolint:unused
 		TraceID              string                              `json:"traceID"`                       //nolint:unused
 		TransactionID        string                              `json:"transactionID"`                 //nolint:unused
+		TransactionMetadata  transaction.Metadata                `json:"-"`                             //nolint:unused
 		TransactionName      string                              `json:"transactionName"`               //nolint:unused
+		TransactionTags      map[string]string                   `json:"-"`                             //nolint:unused
 		VersionCode          string                              `json:"-"`                             //nolint:unused
 		VersionName          string                              `json:"-"`                             //nolint:unused
 	}

--- a/internal/transaction/metadata.go
+++ b/internal/transaction/metadata.go
@@ -1,0 +1,17 @@
+package transaction
+
+import "time"
+
+type (
+	Metadata struct {
+		Dist              string    `json:"dist"`
+		Environment       string    `json:"environment"`
+		HTTPMethod        string    `json:"http.method"`
+		Release           string    `json:"release"`
+		Transaction       string    `json:"transaction"`
+		TransactionEnd    time.Time `json:"transaction.end"`
+		TransactionOp     string    `json:"transaction.op"`
+		TransactionStart  time.Time `json:"transaction.start"`
+		TransactionStatus string    `json:"transaction.status"`
+	}
+)

--- a/internal/transaction/metadata.go
+++ b/internal/transaction/metadata.go
@@ -4,14 +4,14 @@ import "time"
 
 type (
 	Metadata struct {
-		Dist              string    `json:"dist"`
-		Environment       string    `json:"environment"`
-		HTTPMethod        string    `json:"http.method"`
-		Release           string    `json:"release"`
-		Transaction       string    `json:"transaction"`
+		Dist              string    `json:"dist,omitempty"`
+		Environment       string    `json:"environment,omitempty"`
+		HTTPMethod        string    `json:"http.method,omitempty"`
+		Release           string    `json:"release,omitempty"`
+		Transaction       string    `json:"transaction,omitempty"`
 		TransactionEnd    time.Time `json:"transaction.end"`
-		TransactionOp     string    `json:"transaction.op"`
+		TransactionOp     string    `json:"transaction.op,omitempty"`
 		TransactionStart  time.Time `json:"transaction.start"`
-		TransactionStatus string    `json:"transaction.status"`
+		TransactionStatus string    `json:"transaction.status,omitempty"`
 	}
 )


### PR DESCRIPTION
We're going to start receiving transaction tags and metadata added in Relay when the profile is bundled with the transaction. This is so we can read and use them in `vroom`.