### PR TITLE
perf(ios): Correctly fill in idle stacks until next sample

### DIFF
--- a/internal/profile/ios.go
+++ b/internal/profile/ios.go
@@ -289,11 +289,12 @@ func (p *IOS) ReplaceIdleStacks() {
 
 		// replace all idle stacks until next active sample
 		for j := i; j < len(p.Samples); j++ {
-			if p.Samples[j].ThreadID == s.ThreadID && len(p.Samples[j].Frames) == 0 {
+			if p.Samples[j].ThreadID == s.ThreadID {
+				if len(p.Samples[j].Frames) != 0 {
+					break
+				}
 				p.Samples[j].Frames = common
-				continue
 			}
-			break
 		}
 	}
 }


### PR DESCRIPTION
This was breaking as soon as it saw a sample from another thread other than the idle thread that's currently being filled in. This resulted in a O(n^2) runtime instead of desired O(n).