### PR TITLE
doc: document downloader script

### DIFF
--- a/cmd/downloader/README.md
+++ b/cmd/downloader/README.md
@@ -1,0 +1,24 @@
+# Downloader
+
+Script used to download profiles from the GCS bucket
+
+## Prerequisites
+
+* list and read permission for the `sentryio-profiles` bucket
+
+## List of profiles to download
+
+In order to download the profiles it's necessary to first create a list of `gs` paths of the profiles we want to download.
+
+### How To
+
+1. authenticate (for gsutil CLI): `gcloud auth login`
+2. set the sentryio project: `gcloud config set project sentryio`
+3. save gs profiles path to a file: `gsutil ls gs://sentryio-profiles/{org_id}/{project_id}/ | head -n {num_of_profiles_we_want} > profiles_list.txt`
+
+## Download the profiles
+
+1. obtain credentials and put them in a well known location for *Application Default Credential*: `gcloud auth application-default login`
+2. create a folder where the profiles will be stored: `mkdir profiles`
+3. build the downloader: `make downloader`
+4. run the downloader: `./downloader ./profiles_list.txt ./profiles`

--- a/cmd/downloader/README.md
+++ b/cmd/downloader/README.md
@@ -18,6 +18,8 @@ In order to download the profiles it's necessary to first create a list of `gs` 
 
 ## Download the profiles
 
+### How To
+
 1. obtain credentials and put them in a well known location for *Application Default Credential*: `gcloud auth application-default login`
 2. create a folder where the profiles will be stored: `mkdir profiles`
 3. build the downloader: `make downloader`

--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -17,7 +17,7 @@ import (
 func download(client *storage.Client, root string, objects chan string, errorsChan chan error, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	b := client.Bucket("sentry-profiles")
+	b := client.Bucket("sentryio-profiles")
 	for objectName := range objects {
 		parts := strings.Split(objectName, "/")
 		count := len(parts)


### PR DESCRIPTION
* adds a readme on how to use the downloader script plus
* updates the bucket name hardcoded in the script which is now `sentryio-profiles`
