### PR TITLE
fix: Tell craft to not fetch an artifact for this project

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,6 @@
 minVersion: 1.0.0
+artifactProvider:
+  name: none
 targets:
   - name: github
   - name: docker


### PR DESCRIPTION
We don't push an artifact when releasing, so we need to tell craft to not try to fetch one.