### PR TITLE
feat: Pass a template name to render the performance issue as a profile issue

### DIFF
--- a/internal/occurrence/occurrence.go
+++ b/internal/occurrence/occurrence.go
@@ -8,12 +8,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/getsentry/vroom/internal/android"
 	"github.com/getsentry/vroom/internal/debugmeta"
 	"github.com/getsentry/vroom/internal/frame"
 	"github.com/getsentry/vroom/internal/platform"
 	"github.com/getsentry/vroom/internal/profile"
-	"github.com/google/uuid"
 )
 
 type (
@@ -142,6 +143,7 @@ func NewOccurrence(p profile.Profile, ni nodeInfo) *Occurrence {
 		"frame_name":          ni.Node.Name,
 		"frame_package":       ni.Node.Frame.Package,
 		"profile_duration_ns": p.DurationNS(),
+		"template_name":       "profile",
 		"transaction_id":      t.ID,
 		"transaction_name":    t.Name,
 		ProfileID:             p.ID(),


### PR DESCRIPTION
This would be paired with some frontend changes to display the profile issue template instead of performance without having to look at the issue category so we can merge everything under performance issue category.