### PR TITLE
ref: receive a list of profiles ID for flamegraph generation

### DIFF
--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -143,7 +143,7 @@ func (e *environment) newRouter() (*httprouter.Router, error) {
 		{
 			http.MethodPost,
 			"/organizations/:organization_id/projects/:project_id/flamegraph",
-			e.getFlamegraphFromProfileIDs,
+			e.postFlamegraphFromProfileIDs,
 		},
 		{http.MethodGet, "/health", e.getHealth},
 		{http.MethodPost, "/profile", e.postProfile},

--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -140,6 +140,11 @@ func (e *environment) newRouter() (*httprouter.Router, error) {
 			"/organizations/:organization_id/projects/:project_id/flamegraph",
 			e.getFlamegraph,
 		},
+		{
+			http.MethodPost,
+			"/organizations/:organization_id/projects/:project_id/flamegraph",
+			e.getFlamegraphFromProfileIDs,
+		},
 		{http.MethodGet, "/health", e.getHealth},
 		{http.MethodPost, "/profile", e.postProfile},
 	}


### PR DESCRIPTION
Instead of querying snuba for a list of profiles ID, we'll be receiving a list of `profiles_id` directly from `sentry`.

I'm turning this into a `POST` endpoint as we'll be getting a list of profiles id plus (in the near future) an optional list (for each profile id) of span data (start, end) so URL parameters might not be ideal.

Once the `sentry` change will be deployed too, I'll open another PR to remove the unused code/endpoint.