### PR TITLE
feat(android): Use app identifier to improve android frame classifica…

### DIFF
--- a/internal/packageutil/package.go
+++ b/internal/packageutil/package.go
@@ -45,7 +45,11 @@ var (
 )
 
 // IsAndroidApplicationPackage checks if a symbol belongs to an Android system package.
-func IsAndroidApplicationPackage(packageName string) bool {
+func IsAndroidApplicationPackage(packageName string, appIdentifier *string) bool {
+	if appIdentifier != nil {
+		return strings.HasPrefix(packageName, *appIdentifier+".")
+	}
+
 	for _, p := range androidPackagePrefixes {
 		if strings.HasPrefix(packageName, p) {
 			return false

--- a/internal/packageutil/package.go
+++ b/internal/packageutil/package.go
@@ -45,9 +45,9 @@ var (
 )
 
 // IsAndroidApplicationPackage checks if a symbol belongs to an Android system package.
-func IsAndroidApplicationPackage(packageName string, appIdentifier *string) bool {
-	if appIdentifier != nil {
-		return strings.HasPrefix(packageName, *appIdentifier+".")
+func IsAndroidApplicationPackage(packageName string, appIdentifier string) bool {
+	if appIdentifier != "" {
+		return strings.HasPrefix(packageName, appIdentifier+".")
 	}
 
 	for _, p := range androidPackagePrefixes {

--- a/internal/packageutil/package_test.go
+++ b/internal/packageutil/package_test.go
@@ -1,0 +1,54 @@
+package packageutil
+
+import "testing"
+
+func frameType(isApplication bool) string {
+	if isApplication {
+		return "application"
+	}
+	return "system"
+}
+
+var appIdentifier = "io.sentry.samples.android"
+
+func TestIsAndroidApplicationPackage(t *testing.T) {
+	tests := []struct {
+		name          string
+		pkg           string
+		identifier    *string
+		isApplication bool
+	}{
+		{
+			name:          "android system package",
+			pkg:           "android.app",
+			identifier:    nil,
+			isApplication: false,
+		},
+		{
+			name:          "androidx system package",
+			pkg:           "androidx.lifecycle",
+			identifier:    nil,
+			isApplication: false,
+		},
+		{
+			name:          "io.sentry.samples.android application package",
+			pkg:           appIdentifier + ".foo",
+			identifier:    &appIdentifier,
+			isApplication: true,
+		},
+		{
+			name:          "io.sentry.samples.android package must be prefix",
+			pkg:           appIdentifier,
+			identifier:    &appIdentifier,
+			isApplication: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if isApplication := IsAndroidApplicationPackage(tt.pkg, tt.identifier); isApplication != tt.isApplication {
+				t.Fatalf("Expected %s frame but got %s frame", frameType(tt.isApplication), frameType(isApplication))
+			}
+		})
+	}
+}

--- a/internal/packageutil/package_test.go
+++ b/internal/packageutil/package_test.go
@@ -15,31 +15,31 @@ func TestIsAndroidApplicationPackage(t *testing.T) {
 	tests := []struct {
 		name          string
 		pkg           string
-		identifier    *string
+		identifier    string
 		isApplication bool
 	}{
 		{
 			name:          "android system package",
 			pkg:           "android.app",
-			identifier:    nil,
+			identifier:    "",
 			isApplication: false,
 		},
 		{
 			name:          "androidx system package",
 			pkg:           "androidx.lifecycle",
-			identifier:    nil,
+			identifier:    "",
 			isApplication: false,
 		},
 		{
 			name:          "io.sentry.samples.android application package",
 			pkg:           appIdentifier + ".foo",
-			identifier:    &appIdentifier,
+			identifier:    appIdentifier,
 			isApplication: true,
 		},
 		{
 			name:          "io.sentry.samples.android package must be prefix",
 			pkg:           appIdentifier,
-			identifier:    &appIdentifier,
+			identifier:    appIdentifier,
 			isApplication: false,
 		},
 	}

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -31,7 +31,7 @@ type AndroidMethod struct {
 	SourceLine   uint32          `json:"source_line,omitempty"`
 }
 
-func (m AndroidMethod) Frame(appIdentifier *string) frame.Frame {
+func (m AndroidMethod) Frame(appIdentifier string) frame.Frame {
 	className, _, err := m.ExtractPackageNameAndSimpleMethodNameFromAndroidMethod()
 	if err != nil {
 		className = m.ClassName
@@ -123,7 +123,7 @@ type AndroidEvent struct {
 
 type (
 	Android struct {
-		AppIdentifier *string         `json:"-"`
+		AppIdentifier string          `json:"-"`
 		Clock         Clock           `json:"clock"`
 		Events        []AndroidEvent  `json:"events,omitempty"`
 		Methods       []AndroidMethod `json:"methods,omitempty"`

--- a/internal/profile/legacy.go
+++ b/internal/profile/legacy.go
@@ -128,9 +128,7 @@ func (p *LegacyProfile) UnmarshalJSON(b []byte) error {
 		// on the android profile as it will be used when classifying
 		// frames as application vs system
 		metadata := p.GetTransactionMetadata()
-		if metadata.AppIdentifier != "" {
-			t.AppIdentifier = &metadata.AppIdentifier
-		}
+		t.AppIdentifier = metadata.AppIdentifier
 
 		p.Trace = &t
 		p.Profile = nil

--- a/internal/profile/legacy.go
+++ b/internal/profile/legacy.go
@@ -123,6 +123,15 @@ func (p *LegacyProfile) UnmarshalJSON(b []byte) error {
 		if err != nil {
 			return err
 		}
+
+		// if the app identifier is present, then make sure to set it
+		// on the android profile as it will be used when classifying
+		// frames as application vs system
+		metadata := p.GetTransactionMetadata()
+		if metadata.AppIdentifier != "" {
+			t.AppIdentifier = &metadata.AppIdentifier
+		}
+
 		p.Trace = &t
 		p.Profile = nil
 	default:

--- a/internal/transaction/metadata.go
+++ b/internal/transaction/metadata.go
@@ -4,6 +4,7 @@ import "time"
 
 type (
 	Metadata struct {
+		AppIdentifier     string    `json:"app.identifier,omitempty"`
 		Dist              string    `json:"dist,omitempty"`
 		Environment       string    `json:"environment,omitempty"`
 		HTTPMethod        string    `json:"http.method,omitempty"`


### PR DESCRIPTION
…tion

All application frames should have the app identifier as the prefix on the package information. This change uses the app identifier information when it's available to improve the classification of frames as application vs system.