### PR TITLE
mitigate sample count estimation error

### DIFF
--- a/internal/flamegraph/span_util.go
+++ b/internal/flamegraph/span_util.go
@@ -55,6 +55,10 @@ func sliceCallTree(callTree *[]*nodetree.Node, intervals *[]SpanInterval) []*nod
 	for _, node := range *callTree {
 		if duration := getTotalOverlappingDuration(node, intervals); duration > 0 {
 			sampleCount := math.Ceil(float64(duration) / float64(time.Millisecond*10))
+			// here we take the minimum between the node sample count and the estimated
+			// sample count to mitigate the case when we make a wrong estimation due
+			// to sampling frequency not being respected. (Python native code holding
+			// the GIL, php, etc.)
 			node.SampleCount = int(min(uint64(sampleCount), uint64(node.SampleCount)))
 			if children := sliceCallTree(&node.Children, intervals); len(children) > 0 {
 				node.Children = children

--- a/internal/flamegraph/span_util.go
+++ b/internal/flamegraph/span_util.go
@@ -55,7 +55,7 @@ func sliceCallTree(callTree *[]*nodetree.Node, intervals *[]SpanInterval) []*nod
 	for _, node := range *callTree {
 		if duration := getTotalOverlappingDuration(node, intervals); duration > 0 {
 			sampleCount := math.Ceil(float64(duration) / float64(time.Millisecond*10))
-			node.SampleCount = int(sampleCount)
+			node.SampleCount = int(min(uint64(sampleCount), uint64(node.SampleCount)))
 			if children := sliceCallTree(&node.Children, intervals); len(children) > 0 {
 				node.Children = children
 			} else {

--- a/internal/flamegraph/span_util_test.go
+++ b/internal/flamegraph/span_util_test.go
@@ -240,6 +240,33 @@ func TestSliceCallTree(t *testing.T) {
 				},
 			},
 		},
+		{ // this simulate the scenario where the sampling frequency
+			// could not be respected (Python native code holding the GIL,
+			// php, etc.)
+			/*
+				|---------------- NODE ----------------|
+
+						 |------ SPAN 1 ------|
+			*/
+			name: "defective sampling",
+			callTree: []*nodetree.Node{
+				{
+					StartNS:     0,
+					EndNS:       uint64(1000 * time.Millisecond),
+					SampleCount: 2,
+				},
+			},
+			intervals: []SpanInterval{
+				{Start: uint64(250 * time.Millisecond), End: uint64(750 * time.Millisecond)},
+			},
+			output: []*nodetree.Node{
+				{
+					StartNS:     0,
+					EndNS:       uint64(1000 * time.Millisecond),
+					SampleCount: 2,
+				},
+			},
+		},
 	} // end test list
 
 	for _, test := range tests {


### PR DESCRIPTION
In some cases the sampling frequency is not respected.

This is particularly true for php, where the gap between two samples could be up to 30s and for Python, in case there is some native code that is holding the GIL.

This aim at mitigating (not fixing) the potential error estimating sample counts in such scenario.

The idea is that the sample count estimated for a node given a certain interval that overlaps it, should never be more than the original sample count.

So, for example, given a node with a total duration of `30s` but a sample count of `2`, if there is an interval that overlaps for the whole `30s`, instead of estimating a sample count of `3,000`, we'll set it to `2`.