### PR TITLE
feat(functions): Filter out cocoa main function

### DIFF
--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -14,6 +14,12 @@ var (
 		platform.Android: {},
 		platform.Java:    {},
 	}
+
+	functionDenyListByPlatform = map[platform.Platform]map[string]struct{}{
+		platform.Cocoa: {
+			"main": {},
+		},
+	}
 )
 
 type (
@@ -193,8 +199,14 @@ func shouldAggregateFrame(profilePlatform platform.Platform, frameFunction strin
 		return false
 	}
 
-	_, obfuscationSupported := obfuscationSupportedPlatforms[profilePlatform]
-	if obfuscationSupported {
+	// hard coded list of functions that we should not aggregate by
+	if functionDenyList, exists := functionDenyListByPlatform[profilePlatform]; exists {
+		if _, exists = functionDenyList[frameFunction]; exists {
+			return false
+		}
+	}
+
+	if _, obfuscationSupported := obfuscationSupportedPlatforms[profilePlatform]; obfuscationSupported {
 		// obfuscated package names often don't contain a dot (`.`)
 		if !strings.Contains(framePackage, ".") {
 			return false

--- a/internal/nodetree/nodetree_test.go
+++ b/internal/nodetree/nodetree_test.go
@@ -343,6 +343,19 @@ func TestNodeTreeCollectFunctions(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "cocoa main frame",
+			platform: platform.Cocoa,
+			node: Node{
+				DurationNS:    10,
+				IsApplication: true,
+				Frame: frame.Frame{
+					Function: "main",
+					Package:  "iOS-Swift",
+				},
+			},
+			want: map[uint64]CallTreeFunction{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
It's not super useful to show the main function in suspect function for cocoa. Remove it from aggregation.