### PR TITLE
ref(legacy): Make legacy profile the promoted type

### DIFF
--- a/internal/profile/legacy.go
+++ b/internal/profile/legacy.go
@@ -2,7 +2,6 @@ package profile
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -11,23 +10,13 @@ import (
 	"github.com/getsentry/vroom/internal/debugmeta"
 	"github.com/getsentry/vroom/internal/measurements"
 	"github.com/getsentry/vroom/internal/metadata"
-	"github.com/getsentry/vroom/internal/nodetree"
 	"github.com/getsentry/vroom/internal/platform"
-	"github.com/getsentry/vroom/internal/speedscope"
 	"github.com/getsentry/vroom/internal/timeutil"
 	"github.com/getsentry/vroom/internal/transaction"
 )
 
-var ErrProfileHasNoTrace = errors.New("profile has no trace")
-
 type (
 	LegacyProfile struct {
-		RawProfile
-
-		Trace Trace `json:"profile"`
-	}
-
-	RawProfile struct {
 		AndroidAPILevel      uint32                              `json:"android_api_level,omitempty"`
 		Architecture         string                              `json:"architecture,omitempty"`
 		BuildID              string                              `json:"build_id,omitempty"`
@@ -88,86 +77,8 @@ func (p LegacyProfile) StoragePath() string {
 	return StoragePath(p.OrganizationID, p.ProjectID, p.ProfileID)
 }
 
-func (p *LegacyProfile) UnmarshalJSON(b []byte) error {
-	err := json.Unmarshal(b, &p.RawProfile)
-	if err != nil {
-		return err
-	}
-	// when reading a profile from Snuba, there's no profile attached
-	if len(p.Profile) == 0 {
-		return nil
-	}
-	var raw []byte
-	if p.Profile[0] == '"' {
-		var s string
-		err := json.Unmarshal(p.Profile, &s)
-		if err != nil {
-			return err
-		}
-		raw = []byte(s)
-	} else {
-		raw = p.Profile
-	}
-	switch p.Platform {
-	case platform.Cocoa:
-		var t IOS
-		err := json.Unmarshal(raw, &t)
-		if err != nil {
-			return err
-		}
-		p.Trace = &t
-		p.Profile = nil
-	case platform.Android:
-		var t Android
-		err := json.Unmarshal(raw, &t)
-		if err != nil {
-			return err
-		}
-		p.Trace = &t
-		p.Profile = nil
-	default:
-		return errors.New("unknown platform")
-	}
-	return nil
-}
-
-func (p LegacyProfile) CallTrees() (map[uint64][]*nodetree.Node, error) {
-	// Profiles longer than 5s contain a lot of call trees and it produces a lot of noise for the aggregation.
-	// The majority of them might also be timing out and we want to ignore them for the aggregation.
-	if time.Duration(p.DurationNS) > 5*time.Second {
-		return make(map[uint64][]*nodetree.Node), nil
-	}
-	if p.Trace == nil {
-		return nil, ErrProfileHasNoTrace
-	}
-	return p.Trace.CallTrees(), nil
-}
-
 func (p LegacyProfile) IsSampleFormat() bool {
 	return false
-}
-
-func (p *LegacyProfile) Speedscope() (speedscope.Output, error) {
-	o, err := p.Trace.Speedscope()
-	if err != nil {
-		return speedscope.Output{}, err
-	}
-
-	version := FormatVersion(p.VersionName, p.VersionCode)
-
-	o.DurationNS = p.DurationNS
-	o.Metadata = speedscope.ProfileMetadata{
-		ProfileView: speedscope.ProfileView(p.RawProfile),
-		Version:     version,
-	}
-	o.Platform = p.Platform
-	o.ProfileID = p.ProfileID
-	o.ProjectID = p.ProjectID
-	o.TransactionName = p.TransactionName
-	o.Version = version
-	o.Measurements = p.Measurements
-
-	return o, nil
 }
 
 func (p *LegacyProfile) Metadata() metadata.Metadata {
@@ -200,16 +111,6 @@ func (p LegacyProfile) GetEnvironment() string {
 	return p.Environment
 }
 
-func (p LegacyProfile) GetTransaction() transaction.Transaction {
-	return transaction.Transaction{
-		ActiveThreadID: p.Trace.ActiveThreadID(),
-		DurationNS:     p.DurationNS,
-		ID:             p.TransactionID,
-		Name:           p.TransactionName,
-		TraceID:        p.TraceID,
-	}
-}
-
 func (p LegacyProfile) GetDebugMeta() debugmeta.DebugMeta {
 	return p.DebugMeta
 }
@@ -222,31 +123,12 @@ func (p LegacyProfile) GetReceived() time.Time {
 	return p.Received.Time()
 }
 
-func (p *LegacyProfile) Normalize() {
-	switch t := p.Trace.(type) {
-	case *IOS:
-		t.ReplaceIdleStacks()
-	}
-
-	if p.BuildID != "" {
-		p.DebugMeta.Images = append(p.DebugMeta.Images, debugmeta.Image{
-			Type: "proguard",
-			UUID: p.BuildID,
-		})
-		p.BuildID = ""
-	}
-}
-
 func (p LegacyProfile) GetRelease() string {
 	return FormatVersion(p.VersionName, p.VersionCode)
 }
 
 func (p LegacyProfile) GetRetentionDays() int {
 	return p.RetentionDays
-}
-
-func (p LegacyProfile) GetDurationNS() uint64 {
-	return p.Trace.DurationNS()
 }
 
 func (p LegacyProfile) GetTransactionMetadata() transaction.Metadata {


### PR DESCRIPTION
By making the legacy profile the promoted type, this allows us the make the legacy android + ios profile types the top level type, giving us access to the various metadata fields when we work with the raw data.

This also has the added benefit of decoupling the legacy ios and android profiles so the legacy ios profile can be easily removed when we drop support for it.