### PR TITLE
feat(nodejs): Classify node internals as system frames

### DIFF
--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -142,7 +142,7 @@ func (f Frame) IsInline() bool {
 }
 
 func (f Frame) IsNodeApplicationFrame() bool {
-	return !strings.Contains(f.Path, "node_modules")
+	return !strings.HasPrefix(f.Path, "node:internal") && !strings.Contains(f.Path, "node_modules")
 }
 
 func (f Frame) IsCocoaApplicationFrame() bool {

--- a/internal/frame/frame_test.go
+++ b/internal/frame/frame_test.go
@@ -112,6 +112,13 @@ func TestIsNodeApplicationFrame(t *testing.T) {
 			},
 			isApplication: false,
 		},
+		{
+			name: "internal",
+			frame: Frame{
+				Path: "node:internal/process/task_queues",
+			},
+			isApplication: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Node internal frames have abs_path that start with `node:internal`. Correctly classify these as system frames.