### PR TITLE
fix: replace unix epoch timestamp of span intervals with ns elapsed since the start of the profile

### DIFF
--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -80,6 +80,10 @@ func GetFlamegraphFromProfiles(
 					continue
 				}
 				if spans != nil {
+					// span intervals here contains Unix epoch timestamp (in ns).
+					// here we replace their value with the ns elapsed since
+					// the profile.timestamps to be consistent with the sample/node
+					// 'start' and 'end'
 					relativeIntervalsFromAbsoluteTimestamp(&spans, uint64(p.Timestamp().UnixNano()))
 					sortedSpans := mergeIntervals(&spans)
 					for tid, callTree := range callTrees {

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -80,6 +80,7 @@ func GetFlamegraphFromProfiles(
 					continue
 				}
 				if spans != nil {
+					relativeIntervalsFromAbsoluteTimestamp(&spans, uint64(p.Timestamp().UnixNano()))
 					sortedSpans := mergeIntervals(&spans)
 					for tid, callTree := range callTrees {
 						callTrees[tid] = sliceCallTree(&callTree, &sortedSpans)

--- a/internal/flamegraph/span_util.go
+++ b/internal/flamegraph/span_util.go
@@ -9,8 +9,8 @@ import (
 )
 
 type SpanInterval struct {
-	Start uint64 `json:"start"`
-	End   uint64 `json:"end"`
+	Start uint64 `json:"start,string"`
+	End   uint64 `json:"end,string"`
 }
 
 func mergeIntervals(intervals *[]SpanInterval) []SpanInterval {
@@ -34,6 +34,24 @@ func mergeIntervals(intervals *[]SpanInterval) []SpanInterval {
 	}
 
 	return newIntervals
+}
+
+func relativeIntervalsFromAbsoluteTimestamp(intervals *[]SpanInterval, t uint64) {
+	for i := range *intervals {
+		if (*intervals)[i].Start > t {
+			(*intervals)[i].Start = (*intervals)[i].Start - t
+		} else {
+			(*intervals)[i].Start = 0
+		}
+
+		// for the end, this safety check, probably, is not necessary
+		// but better to check anyway
+		if (*intervals)[i].End > t {
+			(*intervals)[i].End = (*intervals)[i].End - t
+		} else {
+			(*intervals)[i].End = 0
+		}
+	}
 }
 
 func max(a, b uint64) uint64 {


### PR DESCRIPTION
This is to be consistent with what is already being used in both the sample and the node structs.