### PR TITLE
fix(call-trees): Check stack and frame id exists

### DIFF
--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -21,8 +21,10 @@ import (
 	"github.com/getsentry/vroom/internal/transaction"
 )
 
-var ErrInvalidStackID = errors.New("profile contains invalid stack id")
-var ErrInvalidFrameID = errors.New("profile contains invalid frame id")
+var (
+	ErrInvalidStackID = errors.New("profile contains invalid stack id")
+	ErrInvalidFrameID = errors.New("profile contains invalid frame id")
+)
 
 type (
 	Device struct {

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -195,7 +195,24 @@ func (p Profile) CallTrees() (map[uint64][]*nodetree.Node, error) {
 			continue
 		}
 
+		if len(p.Trace.Stacks) <= s.StackID {
+			continue
+		}
+
 		stack := p.Trace.Stacks[s.StackID]
+
+		allFramesExist := true
+		for i := len(stack) - 1; i >= 0; i-- {
+			if len(p.Trace.Frames) <= stack[i] {
+				allFramesExist = false
+				break
+			}
+		}
+
+		if !allFramesExist {
+			continue
+		}
+
 		for i := len(stack) - 1; i >= 0; i-- {
 			f := p.Trace.Frames[stack[i]]
 			f.WriteToHash(h)

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -2,6 +2,7 @@ package sample
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"sort"
@@ -19,6 +20,9 @@ import (
 	"github.com/getsentry/vroom/internal/timeutil"
 	"github.com/getsentry/vroom/internal/transaction"
 )
+
+var ErrInvalidStackID = errors.New("profile contains invalid stack id")
+var ErrInvalidFrameID = errors.New("profile contains invalid frame id")
 
 type (
 	Device struct {
@@ -196,21 +200,15 @@ func (p Profile) CallTrees() (map[uint64][]*nodetree.Node, error) {
 		}
 
 		if len(p.Trace.Stacks) <= s.StackID {
-			continue
+			return nil, ErrInvalidStackID
 		}
 
 		stack := p.Trace.Stacks[s.StackID]
 
-		allFramesExist := true
 		for i := len(stack) - 1; i >= 0; i-- {
 			if len(p.Trace.Frames) <= stack[i] {
-				allFramesExist = false
-				break
+				return nil, ErrInvalidFrameID
 			}
-		}
-
-		if !allFramesExist {
-			continue
 		}
 
 		for i := len(stack) - 1; i >= 0; i-- {


### PR DESCRIPTION
In case a bad profile makes it through, we should check that the stack ids and frame ids are valid before accessing them.