### PR TITLE
feat: Release Regex issue type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**
+
+- Release the Regex issue type detection. ([#286](https://github.com/getsentry/vroom/pull/286))
+
 **Internal**
 
 - Enforce changelog modification. ([#282](https://github.com/getsentry/vroom/pull/282))

--- a/internal/occurrence/occurrence.go
+++ b/internal/occurrence/occurrence.go
@@ -83,7 +83,7 @@ const (
 	FileIOType      Type = 2001
 	ImageDecodeType Type = 2002
 	JSONDecodeType  Type = 2003
-	RegexType       Type = 2005
+	RegexType       Type = 2007
 	ViewType        Type = 2006
 
 	EvidenceNameDuration EvidenceName = "Duration"


### PR DESCRIPTION
We're releasing the Regex issue type and we need to switch to the new type: https://github.com/getsentry/sentry/pull/52045.