### PR TITLE
fix: Run changelog CI action only on pull requests

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,18 @@
+name: changelog
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+jobs:
+  build:
+    name: changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const changelog = require('./.github/actions/changelog/index.js')
+            await changelog({github, context, core})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,19 +20,6 @@ defaults:
     shell: bash
 
 jobs:
-  changelog:
-    name: changelog
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          script: |
-            const changelog = require('./.github/actions/changelog/index.js')
-            await changelog({github, context, core})
-
   test-vroom:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 **Internal**
 
+- Run changelog CI action only on pull requests. ([#287](https://github.com/getsentry/vroom/pull/287))
 - Enforce changelog modification. ([#282](https://github.com/getsentry/vroom/pull/282))
 
 ## 23.6.0


### PR DESCRIPTION
The changelog workflow needs to check a PR contains a specific link and we won't have this on the `main` branch.