### PR TITLE
feat: Reintroduce a Cloud Build configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Internal**
 
 - Enforce changelog modification. ([#282](https://github.com/getsentry/vroom/pull/282))
+- Reintroduce a Cloud Build configuration. ([#288](https://github.com/getsentry/vroom/pull/288))
 
 ## 23.6.0
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,12 +1,4 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [
-    'build',
-    '-t', 'us.gcr.io/internal-sentry/vroom:$COMMIT_SHA',
-    '-t', 'us.gcr.io/internal-sentry/vroom:latest',
-    '.'
-    ]
-images: [
-  'us.gcr.io/internal-sentry/vroom:$COMMIT_SHA',
-  'us.gcr.io/internal-sentry/vroom:latest',
-  ]
+  args: ['build', '-t', 'us.gcr.io/internal-sentry/vroom:$COMMIT_SHA', '.']
+images: ['us.gcr.io/internal-sentry/vroom:$COMMIT_SHA']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,12 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [
+    'build',
+    '-t', 'us.gcr.io/internal-sentry/vroom:$COMMIT_SHA',
+    '-t', 'us.gcr.io/internal-sentry/vroom:latest',
+    '.'
+    ]
+images: [
+  'us.gcr.io/internal-sentry/vroom:$COMMIT_SHA',
+  'us.gcr.io/internal-sentry/vroom:latest',
+  ]


### PR DESCRIPTION
In order to match our Cloud Build trigger Terraform definition (https://github.com/getsentry/ops/blob/aaeac7887799595140b81da5e7cd215a94eafee9/terraform/internal-sentry/vroom/trigger.tf), we would need to embed some steps to build the Docker image directly in the Terraform definition.

I don't want to do this as it's more flexible to have the Cloud Build configuration in the service repository so we're re-introducing a Cloud Build config file which matches the existing Terraform definition.