### PR TITLE
fix(functions): Include missing deobfuscation status back in aggregat…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Release the Regex issue type detection. ([#286](https://github.com/getsentry/vroom/pull/286))
 - Skip obfuscated frames from aggregation. ([#285](https://github.com/getsentry/vroom/pull/285))
+- Put back frames with missing obfuscation status for aggregation. ([#289](https://github.com/getsentry/vroom/pull/289))
 
 **Internal**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 **Features**
 
 - Release the Regex issue type detection. ([#286](https://github.com/getsentry/vroom/pull/286))
-- Skip obfuscated frames from aggregation. ([#285](https://github.com/getsentry/vroom/pull/285))
-- Put back frames with missing obfuscation status for aggregation. ([#289](https://github.com/getsentry/vroom/pull/289))
+- Skip obfuscated frames from aggregation. ([#285](https://github.com/getsentry/vroom/pull/285)), ([#289](https://github.com/getsentry/vroom/pull/289))
 
 **Internal**
 

--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -209,7 +209,19 @@ func shouldAggregateFrame(profilePlatform platform.Platform, frame frame.Frame) 
 	}
 
 	if _, obfuscationSupported := obfuscationSupportedPlatforms[profilePlatform]; obfuscationSupported {
-		if frame.Data.DeobfuscationStatus == "missing" || frame.Data.DeobfuscationStatus == "partial" {
+		/*
+			There are 4 possible deobfuscation statuses
+			1. deobfuscated	- The frame was successfully deobfuscated.
+			2. partial			- The frame was only partially deobfuscated.
+												(likely just the class name and not the method name)
+			3. missing			- The frame could not be deobfuscated, not found in the mapping file.
+												(likely to be a system library that should not be obfuscated)
+			4. <no status>	- The frame did not go through deobfuscation. No mapping file specified.
+
+			Only the `partial` status should not be aggregated because only having a deobfuscated
+			class names makes grouping ineffective.
+		*/
+		if frame.Data.DeobfuscationStatus == "partial" {
 			return false
 		}
 

--- a/internal/nodetree/nodetree_test.go
+++ b/internal/nodetree/nodetree_test.go
@@ -303,20 +303,9 @@ func TestNodeTreeCollectFunctions(t *testing.T) {
 						IsApplication: true,
 						Frame: frame.Frame{
 							Data: frame.Data{
-								DeobfuscationStatus: "missing",
-							},
-							Function: "com.example.Thing.doStuff()",
-							Package:  "com.example",
-						},
-					},
-					{
-						DurationNS:    10,
-						IsApplication: true,
-						Frame: frame.Frame{
-							Data: frame.Data{
 								DeobfuscationStatus: "partial",
 							},
-							Function: "com.example.Thing.doStuff()",
+							Function: "com.example.Thing.a()",
 							Package:  "com.example",
 						},
 					},


### PR DESCRIPTION
…ions

Missing deobfuscation status implies system libs that should not be obfuscated. Do not exclude them from aggregation.