### PR TITLE
fix: Look forward instead of backwards when generating a call tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal**
 
 - Change function fingerprints to uint32. ([#295](https://github.com/getsentry/vroom/pull/295))
+- Look forward instead of backwards when generating a call tree. ([#299](https://github.com/getsentry/vroom/pull/299))
 
 ## 23.7.1
 

--- a/internal/flamegraph/flamegraph_test.go
+++ b/internal/flamegraph/flamegraph_test.go
@@ -3,6 +3,9 @@ package flamegraph
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/getsentry/vroom/internal/frame"
 	"github.com/getsentry/vroom/internal/nodetree"
 	"github.com/getsentry/vroom/internal/platform"
@@ -11,9 +14,6 @@ import (
 	"github.com/getsentry/vroom/internal/speedscope"
 	"github.com/getsentry/vroom/internal/testutil"
 	"github.com/getsentry/vroom/internal/timeutil"
-
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestFlamegraphAggregation(t *testing.T) {
@@ -127,17 +127,15 @@ func TestFlamegraphAggregation(t *testing.T) {
 				},
 				Profiles: []interface{}{
 					speedscope.SampledProfile{
-						EndValue:     7,
+						EndValue:     5,
 						IsMainThread: true,
 						Samples: [][]int{
 							{0, 1},
-							{0},
 							{2, 0},
 							{2},
 							{3},
 						},
 						SamplesProfiles: [][]int{
-							{0, 1},
 							{0},
 							{1},
 							{0},
@@ -145,9 +143,9 @@ func TestFlamegraphAggregation(t *testing.T) {
 						},
 						Type:              "sampled",
 						Unit:              "count",
-						Weights:           []uint64{3, 1, 1, 1, 1},
-						SampleCounts:      []uint64{3, 1, 1, 1, 1},
-						SampleDurationsNs: []uint64{20, 10, 0, 10, 10},
+						Weights:           []uint64{2, 1, 1, 1},
+						SampleCounts:      []uint64{2, 1, 1, 1},
+						SampleDurationsNs: []uint64{20, 10, 10, 10},
 					},
 				},
 				Shared: speedscope.SharedData{

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -185,6 +185,7 @@ func (p Profile) GetDurationNS() uint64 {
 	return p.Trace.Samples[maxSampleIndex].ElapsedSinceStartNS - p.Trace.Samples[0].ElapsedSinceStartNS
 }
 
+// CallTrees generates call trees from samples.
 func (p Profile) CallTrees() (map[uint64][]*nodetree.Node, error) {
 	sort.SliceStable(p.Trace.Samples, func(i, j int) bool {
 		return p.Trace.Samples[i].ElapsedSinceStartNS < p.Trace.Samples[j].ElapsedSinceStartNS
@@ -192,57 +193,65 @@ func (p Profile) CallTrees() (map[uint64][]*nodetree.Node, error) {
 
 	activeThreadID := p.Transaction.ActiveThreadID
 	treesByThreadID := make(map[uint64][]*nodetree.Node)
-	previousTimestamp := make(map[uint64]uint64)
+	samplesByThreadID := make(map[uint64][]Sample)
+
+	for _, s := range p.Trace.Samples {
+		samplesByThreadID[s.ThreadID] = append(samplesByThreadID[s.ThreadID], s)
+	}
 
 	var current *nodetree.Node
 	h := fnv.New64()
-	for _, s := range p.Trace.Samples {
-		if s.ThreadID != activeThreadID {
-			continue
-		}
-
-		if len(p.Trace.Stacks) <= s.StackID {
-			return nil, ErrInvalidStackID
-		}
-
-		stack := p.Trace.Stacks[s.StackID]
-
-		for i := len(stack) - 1; i >= 0; i-- {
-			if len(p.Trace.Frames) <= stack[i] {
-				return nil, ErrInvalidFrameID
+	for _, samples := range samplesByThreadID {
+		// The last sample is not represented, only used for its timestamp.
+		for sampleIndex := 0; sampleIndex < len(samples)-1; sampleIndex++ {
+			s := samples[sampleIndex]
+			if s.ThreadID != activeThreadID {
+				continue
 			}
-		}
 
-		for i := len(stack) - 1; i >= 0; i-- {
-			f := p.Trace.Frames[stack[i]]
-			f.WriteToHash(h)
-			fingerprint := h.Sum64()
-			if current == nil {
-				i := len(treesByThreadID[s.ThreadID]) - 1
-				if i >= 0 && treesByThreadID[s.ThreadID][i].Fingerprint == fingerprint &&
-					treesByThreadID[s.ThreadID][i].EndNS == previousTimestamp[s.ThreadID] {
-					current = treesByThreadID[s.ThreadID][i]
-					current.Update(s.ElapsedSinceStartNS)
-				} else {
-					n := nodetree.NodeFromFrame(f, previousTimestamp[s.ThreadID], s.ElapsedSinceStartNS, fingerprint)
-					treesByThreadID[s.ThreadID] = append(treesByThreadID[s.ThreadID], n)
-					current = n
-				}
-			} else {
-				i := len(current.Children) - 1
-				if i >= 0 && current.Children[i].Fingerprint == fingerprint && current.Children[i].EndNS == previousTimestamp[s.ThreadID] {
-					current = current.Children[i]
-					current.Update(s.ElapsedSinceStartNS)
-				} else {
-					n := nodetree.NodeFromFrame(f, previousTimestamp[s.ThreadID], s.ElapsedSinceStartNS, fingerprint)
-					current.Children = append(current.Children, n)
-					current = n
+			if len(p.Trace.Stacks) <= s.StackID {
+				return nil, ErrInvalidStackID
+			}
+
+			stack := p.Trace.Stacks[s.StackID]
+			for i := len(stack) - 1; i >= 0; i-- {
+				if len(p.Trace.Frames) <= stack[i] {
+					return nil, ErrInvalidFrameID
 				}
 			}
+
+			nextTimestamp := samples[sampleIndex+1].ElapsedSinceStartNS
+
+			for i := len(stack) - 1; i >= 0; i-- {
+				f := p.Trace.Frames[stack[i]]
+				f.WriteToHash(h)
+				fingerprint := h.Sum64()
+				if current == nil {
+					i := len(treesByThreadID[s.ThreadID]) - 1
+					if i >= 0 && treesByThreadID[s.ThreadID][i].Fingerprint == fingerprint &&
+						treesByThreadID[s.ThreadID][i].EndNS == s.ElapsedSinceStartNS {
+						current = treesByThreadID[s.ThreadID][i]
+						current.Update(nextTimestamp)
+					} else {
+						n := nodetree.NodeFromFrame(f, s.ElapsedSinceStartNS, nextTimestamp, fingerprint)
+						treesByThreadID[s.ThreadID] = append(treesByThreadID[s.ThreadID], n)
+						current = n
+					}
+				} else {
+					i := len(current.Children) - 1
+					if i >= 0 && current.Children[i].Fingerprint == fingerprint && current.Children[i].EndNS == s.ElapsedSinceStartNS {
+						current = current.Children[i]
+						current.Update(nextTimestamp)
+					} else {
+						n := nodetree.NodeFromFrame(f, s.ElapsedSinceStartNS, nextTimestamp, fingerprint)
+						current.Children = append(current.Children, n)
+						current = n
+					}
+				}
+			}
+			h.Reset()
+			current = nil
 		}
-		h.Reset()
-		previousTimestamp[s.ThreadID] = s.ElapsedSinceStartNS
-		current = nil
 	}
 
 	return treesByThreadID, nil

--- a/internal/sample/sample_test.go
+++ b/internal/sample/sample_test.go
@@ -377,33 +377,35 @@ func TestCallTrees(t *testing.T) {
 			want: map[uint64][]*nodetree.Node{
 				1: {
 					{
-						DurationNS:    50,
+						DurationNS:    40,
 						EndNS:         50,
 						Fingerprint:   15444731332182868858,
 						IsApplication: true,
 						Name:          "function0",
-						SampleCount:   3,
+						SampleCount:   2,
+						StartNS:       10,
 						Frame:         frame.Frame{Function: "function0"},
 						ProfileIDs:    make(map[string]struct{}),
 						Children: []*nodetree.Node{
 							{
-								DurationNS:    50,
+								DurationNS:    40,
 								EndNS:         50,
+								StartNS:       10,
 								Fingerprint:   14164357600995800812,
 								IsApplication: true,
 								Name:          "function1",
-								SampleCount:   3,
+								SampleCount:   2,
 								Frame:         frame.Frame{Function: "function1"},
 								ProfileIDs:    make(map[string]struct{}),
 								Children: []*nodetree.Node{
 									{
-										DurationNS:    40,
+										DurationNS:    10,
 										EndNS:         50,
 										Fingerprint:   9531802423075301657,
 										IsApplication: true,
 										Name:          "function2",
-										SampleCount:   2,
-										StartNS:       10,
+										SampleCount:   1,
+										StartNS:       40,
 										Frame:         frame.Frame{Function: "function2"},
 										ProfileIDs:    make(map[string]struct{}),
 									},
@@ -439,37 +441,26 @@ func TestCallTrees(t *testing.T) {
 			want: map[uint64][]*nodetree.Node{
 				1: {
 					{
-						DurationNS:    40,
+						DurationNS:    30,
 						EndNS:         40,
 						Fingerprint:   15444731332182868858,
 						IsApplication: true,
 						Name:          "function0",
-						SampleCount:   2,
+						SampleCount:   1,
+						StartNS:       10,
 						Frame:         frame.Frame{Function: "function0"},
 						ProfileIDs:    make(map[string]struct{}),
 						Children: []*nodetree.Node{
 							{
-								DurationNS:    40,
+								DurationNS:    30,
 								EndNS:         40,
 								Fingerprint:   14164357600995800812,
 								IsApplication: true,
 								Name:          "function1",
-								SampleCount:   2,
+								SampleCount:   1,
+								StartNS:       10,
 								Frame:         frame.Frame{Function: "function1"},
 								ProfileIDs:    make(map[string]struct{}),
-								Children: []*nodetree.Node{
-									{
-										DurationNS:    30,
-										EndNS:         40,
-										Fingerprint:   9531802423075301657,
-										IsApplication: true,
-										Name:          "function2",
-										SampleCount:   1,
-										StartNS:       10,
-										Frame:         frame.Frame{Function: "function2"},
-										ProfileIDs:    make(map[string]struct{}),
-									},
-								},
 							},
 						},
 					},
@@ -504,34 +495,24 @@ func TestCallTrees(t *testing.T) {
 				1: {
 					{
 						DurationNS:    10,
-						EndNS:         10,
+						EndNS:         20,
 						Fingerprint:   15444731332182868858,
 						IsApplication: true,
 						Name:          "function0",
 						SampleCount:   1,
+						StartNS:       10,
 						Frame:         frame.Frame{Function: "function0"},
 						ProfileIDs:    make(map[string]struct{}),
 					},
 					{
 						DurationNS:    10,
-						EndNS:         20,
+						EndNS:         30,
 						Fingerprint:   15444731332182868859,
 						IsApplication: true,
 						Name:          "function1",
 						SampleCount:   1,
-						StartNS:       10,
-						Frame:         frame.Frame{Function: "function1"},
-						ProfileIDs:    make(map[string]struct{}),
-					},
-					{
-						DurationNS:    10,
-						EndNS:         30,
-						Fingerprint:   15444731332182868856,
-						IsApplication: true,
-						Name:          "function2",
-						SampleCount:   1,
 						StartNS:       20,
-						Frame:         frame.Frame{Function: "function2"},
+						Frame:         frame.Frame{Function: "function1"},
 						ProfileIDs:    make(map[string]struct{}),
 					},
 				},
@@ -1026,6 +1007,11 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 								StackID:             0,
 								ThreadID:            0,
 							},
+							{
+								ElapsedSinceStartNS: 10,
+								StackID:             0,
+								ThreadID:            0,
+							},
 						},
 					},
 				},
@@ -1033,6 +1019,8 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 			output: map[uint64][]*nodetree.Node{
 				0: {
 					{
+						DurationNS:    10,
+						EndNS:         10,
 						Fingerprint:   1628006971372193492,
 						IsApplication: true,
 						Name:          "main",
@@ -1071,6 +1059,11 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 								StackID:             0,
 								ThreadID:            0,
 							},
+							{
+								ElapsedSinceStartNS: 10,
+								StackID:             0,
+								ThreadID:            0,
+							},
 						},
 					},
 				},
@@ -1078,6 +1071,8 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 			output: map[uint64][]*nodetree.Node{
 				0: {
 					{
+						DurationNS:    10,
+						EndNS:         10,
 						Fingerprint:   1628006971372193492,
 						IsApplication: true,
 						Name:          "main",
@@ -1117,6 +1112,11 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 								StackID:             0,
 								ThreadID:            0,
 							},
+							{
+								ElapsedSinceStartNS: 10,
+								StackID:             0,
+								ThreadID:            0,
+							},
 						},
 					},
 				},
@@ -1124,6 +1124,8 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 			output: map[uint64][]*nodetree.Node{
 				0: {
 					{
+						DurationNS:    10,
+						EndNS:         10,
 						Fingerprint:   12857020554704472368,
 						IsApplication: false,
 						Name:          "Threading.run",


### PR DESCRIPTION
Currently, we're look at the previous timestamp to calculate the duration of a function. The frontend is doing the opposite and is looking at the next timestamp.

During various debates, we've decided to look at the next timestamp. This PR aligns with this decision.