### PR TITLE
fix(android): Ignore arg and return types for android issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**
+
+- Fix android issue frame detection. ([#305](https://github.com/getsentry/vroom/pull/305))
+
 ## 23.8.0
 
 **Internal**

--- a/internal/occurrence/detect_frame.go
+++ b/internal/occurrence/detect_frame.go
@@ -12,8 +12,8 @@ import (
 
 type (
 	DetectFrameOptions interface {
-		OnlyCheckActiveThread() bool
-		CheckNode(*nodetree.Node) *nodeInfo
+		onlyCheckActiveThread() bool
+		checkNode(*nodetree.Node) *nodeInfo
 	}
 
 	DetectExactFrameOptions struct {
@@ -77,11 +77,11 @@ const (
 	XPC              Category = "xpc"
 )
 
-func (options DetectExactFrameOptions) OnlyCheckActiveThread() bool {
+func (options DetectExactFrameOptions) onlyCheckActiveThread() bool {
 	return options.ActiveThreadOnly
 }
 
-func (options DetectExactFrameOptions) CheckNode(n *nodetree.Node) *nodeInfo {
+func (options DetectExactFrameOptions) checkNode(n *nodetree.Node) *nodeInfo {
 	// Check if we have a list of functions associated to the package.
 	functions, exists := options.FunctionsByPackage[n.Package]
 	if !exists {
@@ -112,11 +112,11 @@ func (options DetectExactFrameOptions) CheckNode(n *nodetree.Node) *nodeInfo {
 	return &ni
 }
 
-func (options DetectAndroidFrameOptions) OnlyCheckActiveThread() bool {
+func (options DetectAndroidFrameOptions) onlyCheckActiveThread() bool {
 	return options.ActiveThreadOnly
 }
 
-func (options DetectAndroidFrameOptions) CheckNode(n *nodetree.Node) *nodeInfo {
+func (options DetectAndroidFrameOptions) checkNode(n *nodetree.Node) *nodeInfo {
 	// Check if we have a list of functions associated to the package.
 	functions, exists := options.FunctionsByPackage[n.Package]
 	if !exists {
@@ -467,7 +467,7 @@ func detectFrame(
 ) {
 	// List nodes matching criteria
 	nodes := make(map[nodeKey]nodeInfo)
-	if options.OnlyCheckActiveThread() {
+	if options.onlyCheckActiveThread() {
 		callTrees, exists := callTreesPerThreadID[p.Transaction().ActiveThreadID]
 		if !exists {
 			return
@@ -517,7 +517,7 @@ func detectFrameInNode(
 	if issueDetected {
 		return nil
 	}
-	ni := options.CheckNode(n)
+	ni := options.checkNode(n)
 	if ni != nil {
 		nk := nodeKey{Package: ni.Node.Package, Function: ni.Node.Name}
 		if _, exists := nodes[nk]; !exists {

--- a/internal/occurrence/detect_frame_test.go
+++ b/internal/occurrence/detect_frame_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestDetectFrameInCallTree(t *testing.T) {
 	tests := []struct {
-		job  DetectExactFrameOptions
+		job  DetectFrameOptions
 		name string
 		node *nodetree.Node
 		want map[nodeKey]nodeInfo
@@ -787,6 +787,69 @@ func TestDetectFrameInCallTree(t *testing.T) {
 							InApp:    &testutil.True,
 							Line:     0,
 							Package:  "CoreFoundation",
+							Path:     "path",
+						},
+					},
+				},
+			},
+		},
+		{
+			job: DetectAndroidFrameOptions{
+				DurationThreshold: 16 * time.Millisecond,
+				FunctionsByPackage: map[string]map[string]Category{
+					"android.graphics": {
+						"android.graphics.BitmapFactory.decodeStream": ImageDecode,
+					},
+				},
+			},
+			name: "Detect android frame",
+			node: &nodetree.Node{
+				DurationNS:    uint64(30 * time.Millisecond),
+				EndNS:         uint64(30 * time.Millisecond),
+				Fingerprint:   0,
+				IsApplication: true,
+				Line:          0,
+				Name:          "android.graphics.BitmapFactory.decodeStream(java.io.InputStream, android.graphics.Rect, android.graphics.BitmapFactory$Options): android.graphics.Bitmap",
+				Package:       "android.graphics",
+				Path:          "path",
+				StartNS:       0,
+				Frame: frame.Frame{
+					Function: "android.graphics.BitmapFactory.decodeStream(java.io.InputStream, android.graphics.Rect, android.graphics.BitmapFactory$Options): android.graphics.Bitmap",
+					InApp:    &testutil.True,
+					Package:  "android.graphics",
+					Path:     "path",
+				},
+				Children: []*nodetree.Node{},
+			},
+			want: map[nodeKey]nodeInfo{
+				{
+					Package:  "android.graphics",
+					Function: "android.graphics.BitmapFactory.decodeStream(java.io.InputStream, android.graphics.Rect, android.graphics.BitmapFactory$Options): android.graphics.Bitmap",
+				}: {
+					Category: ImageDecode,
+					Node: nodetree.Node{
+						DurationNS:    uint64(30 * time.Millisecond),
+						EndNS:         uint64(30 * time.Millisecond),
+						Fingerprint:   0,
+						IsApplication: true,
+						Line:          0,
+						Name:          "android.graphics.BitmapFactory.decodeStream(java.io.InputStream, android.graphics.Rect, android.graphics.BitmapFactory$Options): android.graphics.Bitmap",
+						Package:       "android.graphics",
+						Path:          "path",
+						StartNS:       0,
+						Frame: frame.Frame{
+							Function: "android.graphics.BitmapFactory.decodeStream(java.io.InputStream, android.graphics.Rect, android.graphics.BitmapFactory$Options): android.graphics.Bitmap",
+							InApp:    &testutil.True,
+							Package:  "android.graphics",
+							Path:     "path",
+						},
+					},
+					StackTrace: []frame.Frame{
+						{
+							Function: "android.graphics.BitmapFactory.decodeStream(java.io.InputStream, android.graphics.Rect, android.graphics.BitmapFactory$Options): android.graphics.Bitmap",
+							InApp:    &testutil.True,
+							Line:     0,
+							Package:  "android.graphics",
 							Path:     "path",
 						},
 					},


### PR DESCRIPTION
When the signature was deobfuscated, it broke android issues detection because function name now contains the fully deobfuscated symbol names. To handle this, we're loosening the condition to match on just the function name while ignoring the argument and return types.