### PR TITLE
feat: Filter frame drop candidates based on thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Improve frame drop detection algorithm. ([#304](https://github.com/getsentry/vroom/pull/304))
 - Accept and return the time a profile started at in a timestamp field on Android. ([#306](https://github.com/getsentry/vroom/pull/306))
+- Filter frame drop candidates based on thresholds. ([#308](https://github.com/getsentry/vroom/pull/308))
 
 **Internal**
 

--- a/internal/occurrence/frame_drop_test.go
+++ b/internal/occurrence/frame_drop_test.go
@@ -490,13 +490,13 @@ func TestFindFrameDrop(t *testing.T) {
 								},
 								Children: []*nodetree.Node{
 									{
-										DurationNS:    uint64(100 * time.Millisecond),
+										DurationNS:    uint64(150 * time.Millisecond),
 										EndNS:         uint64(250 * time.Millisecond),
 										IsApplication: true,
 										Name:          "child2-1",
 										Package:       "package",
 										Path:          "path",
-										StartNS:       uint64(150 * time.Millisecond),
+										StartNS:       uint64(100 * time.Millisecond),
 										Frame: frame.Frame{
 											Function: "child2-1",
 											InApp:    &testutil.True,
@@ -570,7 +570,7 @@ func TestFindFrameDrop(t *testing.T) {
 						Tags: map[string]string{},
 					},
 					EvidenceData: map[string]interface{}{
-						"frame_duration_ns":   uint64(100000000),
+						"frame_duration_ns":   uint64(150000000),
 						"frame_module":        "",
 						"frame_name":          "child2-1",
 						"frame_package":       "package",


### PR DESCRIPTION
Frame draps are supposed to happened at the beginning of the frozen frame and covering a good portion of the duration of the frozen frame. In this PR, I added 2 filters to weed out bad candidates and loosened when the start and end of the frame drop cause can be.

Now we'll make sure the cause is:
- within the first 20% of the frozen frame
- at least 50% of the frozen frame duration
- contained inside the frozen frame with a 5% margin at the start and end
- an application frame