### PR TITLE
Bump go sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+**Internal**
+
+- Bump the Go SDK to `v0.24.0`. ([#313](https://github.com/getsentry/vroom/pull/313))
+- Remove the `TracesSampler` in favour of Inbound Data Filters. ([#313](https://github.com/getsentry/vroom/pull/313))
+
+
 ## 23.9.0
 
 **Features**

--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -173,15 +173,10 @@ func main() {
 	err = sentry.Init(sentry.ClientOptions{
 		Dsn:                   env.config.SentryDSN,
 		EnableTracing:         true,
+		TracesSampleRate:      1.0,
 		Environment:           env.config.Environment,
 		Release:               release,
 		BeforeSendTransaction: httputil.SetHTTPStatusCodeTag,
-		TracesSampler: func(ctx sentry.SamplingContext) float64 {
-			if ctx.Span.Name == "GET /health" {
-				return 0
-			}
-			return 1
-		},
 	})
 	if err != nil {
 		log.Fatal().Err(err).Msg("can't initialize sentry")

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/CAFxX/httpcompression v0.0.8
 	github.com/andybalholm/brotli v1.0.5
 	github.com/fsouza/fake-gcs-server v1.44.0
-	github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af
+	github.com/getsentry/sentry-go v0.24.1
 	github.com/goccy/go-json v0.10.0
 	github.com/gojek/heimdall/v7 v7.0.2
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -893,8 +893,8 @@ github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXt
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
-github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af h1:yqkuRYkdOijB0qKTnaIcSNP6UxdYEoTdu86M1meMwws=
-github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go v0.24.1 h1:W6/0GyTy8J6ge6lVCc94WB6Gx2ZuLrgopnn9w8Hiwuk=
+github.com/getsentry/sentry-go v0.24.1/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=


### PR DESCRIPTION
Bump the Go SDK to [v0.24.1](https://github.com/getsentry/sentry-go/releases/tag/v0.24.1) as well as remove the `TracesSampler` in favour of using [`InboundFilters`](https://docs.sentry.io/product/data-management-settings/filtering/#transactions-coming-from-healthcheck).