### PR TITLE
feat(statistical-detectors): Add new endpoint for regressed functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 **Internal**
 
 - Rename the frame drop issue title. ([#315](https://github.com/getsentry/vroom/pull/315))
+- Add new endpoint for regressed functions. ([#318](https://github.com/getsentry/vroom/pull/318))
 
 ## 23.9.1
 

--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -147,6 +147,7 @@ func (e *environment) newRouter() (*httprouter.Router, error) {
 		},
 		{http.MethodGet, "/health", e.getHealth},
 		{http.MethodPost, "/profile", e.postProfile},
+		{http.MethodPost, "/regressed", e.postRegressed},
 	}
 
 	router := httprouter.New()

--- a/cmd/vroom/regressed.go
+++ b/cmd/vroom/regressed.go
@@ -20,13 +20,17 @@ func (env *environment) postRegressed(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	occurrences := occurrence.ProcessRegressedFunctions(
-		ctx,
-		hub,
-		env.storage,
-		regressedFunctions,
-		10,
-	)
+	occurrences := []*occurrence.Occurrence{}
+	for _, regressedFunction := range regressedFunctions {
+		occurrence, err := occurrence.ProcessRegressedFunction(ctx, env.storage, regressedFunction)
+		if err != nil {
+			hub.CaptureException(err)
+			continue
+		} else if occurrence == nil {
+			continue
+		}
+		occurrences = append(occurrences, occurrence)
+	}
 
 	s := sentry.StartSpan(ctx, "json.marshal")
 	data := struct {

--- a/cmd/vroom/regressed.go
+++ b/cmd/vroom/regressed.go
@@ -30,8 +30,8 @@ func (env *environment) postRegressed(w http.ResponseWriter, r *http.Request) {
 
 	s := sentry.StartSpan(ctx, "json.marshal")
 	data := struct {
-		occurrences int
-	}{occurrences: len(occurrences)}
+		Occurrences int `json:"occurrences"`
+	}{Occurrences: len(occurrences)}
 	b, err := json.Marshal(data)
 	s.Finish()
 	if err != nil {

--- a/cmd/vroom/regressed.go
+++ b/cmd/vroom/regressed.go
@@ -22,7 +22,10 @@ func (env *environment) postRegressed(w http.ResponseWriter, r *http.Request) {
 
 	occurrences := []*occurrence.Occurrence{}
 	for _, regressedFunction := range regressedFunctions {
+		s := sentry.StartSpan(ctx, "processing")
+		s.Description = "Generating occurrence for payload"
 		occurrence, err := occurrence.ProcessRegressedFunction(ctx, env.storage, regressedFunction)
+		s.Finish()
 		if err != nil {
 			hub.CaptureException(err)
 			continue

--- a/cmd/vroom/regressed.go
+++ b/cmd/vroom/regressed.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/vroom/internal/occurrence"
+)
+
+func (env *environment) postRegressed(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	hub := sentry.GetHubFromContext(ctx)
+
+	regressedFunctions, err := decodeRegressedFunctionPayload(ctx, r)
+	if err != nil {
+		hub.CaptureException(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	occurrences := occurrence.ProcessRegressedFunctions(
+		ctx,
+		hub,
+		env.storage,
+		regressedFunctions,
+		10,
+	)
+
+	s := sentry.StartSpan(ctx, "json.marshal")
+	data := struct {
+		occurrences int
+	}{occurrences: len(occurrences)}
+	b, err := json.Marshal(data)
+	s.Finish()
+	if err != nil {
+		hub.CaptureException(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	occurrenceMessages, err := occurrence.GenerateKafkaMessageBatch(occurrences)
+	if err != nil {
+		hub.CaptureException(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	s = sentry.StartSpan(ctx, "processing")
+	s.Description = "Send occurrences to Kafka"
+	err = env.occurrencesWriter.WriteMessages(ctx, occurrenceMessages...)
+	s.Finish()
+	if err != nil {
+		hub.CaptureException(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(b)
+}
+
+func decodeRegressedFunctionPayload(ctx context.Context, r *http.Request) ([]occurrence.RegressedFunction, error) {
+	s := sentry.StartSpan(ctx, "processing")
+	s.Description = "Decoding payload"
+	defer s.Finish()
+
+	var regressedFunctions []occurrence.RegressedFunction
+	err := json.NewDecoder(r.Body).Decode(&regressedFunctions)
+	return regressedFunctions, err
+}

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -185,13 +185,10 @@ func (f Frame) IsPHPApplicationFrame() bool {
 }
 
 func (f Frame) Fingerprint() uint32 {
-	frameFunction := f.Function
-	framePackage := f.ModuleOrPackage()
-
 	h := fnv.New64()
-	h.Write([]byte(framePackage))
+	h.Write([]byte(f.ModuleOrPackage()))
 	h.Write([]byte{':'})
-	h.Write([]byte(frameFunction))
+	h.Write([]byte(f.Function))
 
 	// casting to an uint32 here because snuba does not handle uint64 values well
 	// as it is converted to a float somewhere not changing to the 32 bit hash

--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -246,13 +246,13 @@ func (n *Node) Close(timestamp uint64) {
 	}
 }
 
-func FindNodeByFingerprint(target uint32, nodes []*Node) *Node {
-	for _, node := range nodes {
-		if node.Frame.Fingerprint() == target {
-			return node
-		}
+func (n *Node) FindNodeByFingerprint(target uint32) *Node {
+	if n.Frame.Fingerprint() == target {
+		return n
+	}
 
-		node := FindNodeByFingerprint(target, node.Children)
+	for _, child := range n.Children {
+		node := child.FindNodeByFingerprint(target)
 		if node != nil {
 			return node
 		}

--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -2,7 +2,6 @@ package nodetree
 
 import (
 	"hash"
-	"hash/fnv"
 	"strings"
 
 	"github.com/getsentry/vroom/internal/frame"
@@ -139,9 +138,6 @@ func (n *Node) CollectFunctions(
 		applicationDurationNS = n.DurationNS
 	}
 
-	frameFunction := n.Frame.Function
-	framePackage := n.Frame.ModuleOrPackage()
-
 	var selfTimeNS uint64
 
 	if shouldAggregateFrame(profilePlatform, n.Frame) {
@@ -165,23 +161,18 @@ func (n *Node) CollectFunctions(
 		}
 
 		if selfTimeNS > 0 {
-			h := fnv.New64()
-			h.Write([]byte(framePackage))
-			h.Write([]byte{':'})
-			h.Write([]byte(frameFunction))
-
 			// casting to an uint32 here because snuba does not handle uint64 values
 			// well as it is converted to a float somewhere
 			// not changing to the 32 bit hash function here to preserve backwards
 			// compatibility with existing fingerprints that we can cast
-			fingerprint := uint32(h.Sum64())
+			fingerprint := n.Frame.Fingerprint()
 
 			function, exists := results[fingerprint]
 			if !exists {
 				results[fingerprint] = CallTreeFunction{
 					Fingerprint:   fingerprint,
 					Function:      n.Frame.Function,
-					Package:       framePackage,
+					Package:       n.Frame.ModuleOrPackage(),
 					InApp:         n.IsApplication,
 					SelfTimesNS:   []uint64{selfTimeNS},
 					SumSelfTimeNS: selfTimeNS,
@@ -253,4 +244,18 @@ func (n *Node) Close(timestamp uint64) {
 	for _, c := range n.Children {
 		c.Close(timestamp)
 	}
+}
+
+func FindNodeByFingerprint(target uint32, nodes []*Node) *Node {
+	for _, node := range nodes {
+		if node.Frame.Fingerprint() != target {
+			return node
+		}
+		node := FindNodeByFingerprint(target, node.Children)
+		if node != nil {
+			return node
+		}
+	}
+
+	return nil
 }

--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -248,9 +248,10 @@ func (n *Node) Close(timestamp uint64) {
 
 func FindNodeByFingerprint(target uint32, nodes []*Node) *Node {
 	for _, node := range nodes {
-		if node.Frame.Fingerprint() != target {
+		if node.Frame.Fingerprint() == target {
 			return node
 		}
+
 		node := FindNodeByFingerprint(target, node.Children)
 		if node != nil {
 			return node

--- a/internal/occurrence/occurrence.go
+++ b/internal/occurrence/occurrence.go
@@ -210,7 +210,7 @@ func FromRegressedFunction(p profile.Profile, regressed RegressedFunction, f fra
 	fingerprint := fmt.Sprintf("%x", regressed.Fingerprint)
 	beforeP95 := time.Duration(regressed.AggregateRange1).Round(10 * time.Microsecond)
 	afterP95 := time.Duration(regressed.AggregateRange2).Round(10 * time.Microsecond)
-	regressionText := fmt.Sprintf("P95 frame duration increased from %s to %s.", beforeP95, afterP95)
+	regressionText := fmt.Sprintf("P95 function duration increased from %s to %s.", beforeP95, afterP95)
 
 	return &Occurrence{
 		Culprit:       fullyQualifiedName,
@@ -265,7 +265,7 @@ func FromRegressedFunction(p profile.Profile, regressed RegressedFunction, f fra
 		},
 		Fingerprint: []string{fingerprint},
 		ID:          eventID(),
-		IssueTitle:  "Frame Duration Regression",
+		IssueTitle:  "Function Duration Regression",
 		Level:       "info",
 		ProjectID:   regressed.ProjectID,
 		Subtitle:    regressionText,

--- a/internal/occurrence/occurrence.go
+++ b/internal/occurrence/occurrence.go
@@ -222,6 +222,7 @@ func FromRegressedFunction(p profile.Profile, regressed RegressedFunction, f fra
 			ProjectID:      regressed.ProjectID,
 			Received:       now,
 			Timestamp:      now,
+			Tags:           make(map[string]string),
 		},
 		EvidenceData: map[string]interface{}{
 			"organization_id": regressed.OrganizationID,

--- a/internal/occurrence/regressed_frame.go
+++ b/internal/occurrence/regressed_frame.go
@@ -65,6 +65,9 @@ func ProcessRegressedFunction(
 	var node *nodetree.Node
 	for _, calltree := range calltrees {
 		node = calltree.FindNodeByFingerprint(regressedFunction.Fingerprint)
+		if node != nil {
+			break
+		}
 	}
 	s.Finish()
 

--- a/internal/occurrence/regressed_frame.go
+++ b/internal/occurrence/regressed_frame.go
@@ -20,7 +20,7 @@ type RegressedFunction struct {
 	AbsolutePercentageChange float64 `json:"absolute_percentage_change"`
 	AggregateRange1          float64 `json:"aggregate_range_1"`
 	AggregateRange2          float64 `json:"aggregate_range_2"`
-	Breakpoint               int64   `json:"breakpoint"`
+	Breakpoint               uint64  `json:"breakpoint"`
 	TrendDifference          float64 `json:"trend_difference"`
 	TrendPercentage          float64 `json:"trend_percentage"`
 	UnweightedPValue         float64 `json:"unweighted_p_value"`

--- a/internal/occurrence/regressed_frame.go
+++ b/internal/occurrence/regressed_frame.go
@@ -106,16 +106,18 @@ func ProcessRegressedFunctions(
 		}()
 	}
 
-	for _, regressedFunction := range regressedFunctions {
-		regressedChan <- regressedFunction
-	}
-	close(regressedChan)
+	go func() {
+		for _, regressedFunction := range regressedFunctions {
+			regressedChan <- regressedFunction
+		}
+		close(regressedChan)
 
-	// wait until all the profiles have been processed
-	// then we can close the occurrence channel and collect
-	// any occurrences that have been created
-	wg.Wait()
-	close(occurrenceChan)
+		// wait until all the profiles have been processed
+		// then we can close the occurrence channel and collect
+		// any occurrences that have been created
+		wg.Wait()
+		close(occurrenceChan)
+	}()
 
 	occurrences := []*Occurrence{}
 	for occurrence := range occurrenceChan {

--- a/internal/occurrence/regressed_frame.go
+++ b/internal/occurrence/regressed_frame.go
@@ -1,0 +1,127 @@
+package occurrence
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/vroom/internal/nodetree"
+	"github.com/getsentry/vroom/internal/profile"
+	"github.com/getsentry/vroom/internal/storageutil"
+	"gocloud.dev/blob"
+)
+
+type RegressedFunction struct {
+	OrganizationID           uint64  `json:"organization_id"`
+	ProjectID                uint64  `json:"project_id"`
+	ProfileID                string  `json:"profile_id"`
+	Fingerprint              uint32  `json:"fingerprint"`
+	AbsolutePercentageChange float64 `json:"absolute_percentage_change"`
+	AggregateRange1          float64 `json:"aggregate_range_1"`
+	AggregateRange2          float64 `json:"aggregate_range_2"`
+	Breakpoint               int64   `json:"breakpoint"`
+	TrendDifference          float64 `json:"trend_difference"`
+	TrendPercentage          float64 `json:"trend_percentage"`
+	UnweightedPValue         float64 `json:"unweighted_p_value"`
+	UnweightedTValue         float64 `json:"unweighted_t_value"`
+}
+
+func processRegressedFunction(
+	ctx context.Context,
+	profilesBucket *blob.Bucket,
+	regressedFunction RegressedFunction,
+) (*Occurrence, error) {
+
+	s := sentry.StartSpan(ctx, "profile.read")
+	s.Description = "Read profile from GCS"
+	var p profile.Profile
+	objectName := profile.StoragePath(
+		regressedFunction.OrganizationID,
+		regressedFunction.ProjectID,
+		regressedFunction.ProfileID,
+	)
+	err := storageutil.UnmarshalCompressed(ctx, profilesBucket, objectName, &p)
+	s.Finish()
+	if err != nil {
+		return nil, err
+	}
+
+	s = sentry.StartSpan(ctx, "processing")
+	s.Description = "Generate call trees"
+	calltreesByTID, err := p.CallTrees()
+	s.Finish()
+
+	if err != nil {
+		return nil, err
+	}
+
+	calltrees, exists := calltreesByTID[p.Transaction().ActiveThreadID]
+	if !exists {
+		return nil, errors.New("calltree not found")
+	}
+
+	s = sentry.StartSpan(ctx, "processing")
+	s.Description = "Searching for fingerprint"
+	node := nodetree.FindNodeByFingerprint(regressedFunction.Fingerprint, calltrees)
+	s.Finish()
+
+	if node == nil {
+		return nil, errors.New("fingerprint not found")
+	}
+
+	return FromRegressedFunction(p, regressedFunction, node.Frame), nil
+}
+
+func ProcessRegressedFunctions(
+	ctx context.Context,
+	hub *sentry.Hub,
+	profilesBucket *blob.Bucket,
+	regressedFunctions []RegressedFunction,
+	numWorkers int,
+) []*Occurrence {
+	if len(regressedFunctions) < numWorkers {
+		numWorkers = len(regressedFunctions)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(regressedFunctions))
+
+	regressedChan := make(chan RegressedFunction, numWorkers)
+	occurrenceChan := make(chan *Occurrence)
+
+	for i := 0; i < numWorkers; i++ {
+		go func() {
+			for regressedFunction := range regressedChan {
+				defer wg.Done()
+				occurrence, err := processRegressedFunction(ctx, profilesBucket, regressedFunction)
+				if err != nil {
+					hub.CaptureException(err)
+					continue
+				} else if occurrence == nil {
+					continue
+				}
+
+				occurrenceChan <- occurrence
+			}
+		}()
+	}
+
+	for _, regressedFunction := range regressedFunctions {
+		regressedChan <- regressedFunction
+	}
+	close(regressedChan)
+
+	// wait until all the profiles have been processed
+	// then we can close the occurrence channel and collect
+	// any occurrences that have been created
+	wg.Wait()
+	close(occurrenceChan)
+
+	occurrences := []*Occurrence{}
+	for occurrence := range occurrenceChan {
+		occurrences = append(occurrences, occurrence)
+	}
+
+	return occurrences
+}

--- a/internal/occurrence/regressed_frame.go
+++ b/internal/occurrence/regressed_frame.go
@@ -27,7 +27,7 @@ type RegressedFunction struct {
 	UnweightedTValue         float64 `json:"unweighted_t_value"`
 }
 
-func processRegressedFunction(
+func ProcessRegressedFunction(
 	ctx context.Context,
 	profilesBucket *blob.Bucket,
 	regressedFunction RegressedFunction,
@@ -93,7 +93,7 @@ func ProcessRegressedFunctions(
 		go func() {
 			defer wg.Done()
 			for regressedFunction := range regressedChan {
-				occurrence, err := processRegressedFunction(ctx, profilesBucket, regressedFunction)
+				occurrence, err := ProcessRegressedFunction(ctx, profilesBucket, regressedFunction)
 				if err != nil {
 					hub.CaptureException(err)
 					continue

--- a/internal/occurrence/regressed_frame.go
+++ b/internal/occurrence/regressed_frame.go
@@ -62,7 +62,10 @@ func ProcessRegressedFunction(
 
 	s = sentry.StartSpan(ctx, "processing")
 	s.Description = "Searching for fingerprint"
-	node := nodetree.FindNodeByFingerprint(regressedFunction.Fingerprint, calltrees)
+	var node *nodetree.Node
+	for _, calltree := range calltrees {
+		node = calltree.FindNodeByFingerprint(regressedFunction.Fingerprint)
+	}
 	s.Finish()
 
 	if node == nil {


### PR DESCRIPTION
This introduces a new endpoint to create occurrences from regressed functions. When the detectors pick up a regressed function, it'll post a batch of them to this endpoint. An example will be loaded for each regression and used to fill in the details of the regression occurrence.

New group type added in getsentry/sentry#56862