### PR TITLE
fix: Compare the duration of the frame to the minimum duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Bug Fixes**
 
 - Close remaining open events in Android profiles. ([#316](https://github.com/getsentry/vroom/pull/316))
+- Enforce minimum frame duration for frame drop issue. ([#319](https://github.com/getsentry/vroom/pull/319))
 
 **Internal**
 

--- a/internal/occurrence/frame_drop.go
+++ b/internal/occurrence/frame_drop.go
@@ -42,9 +42,9 @@ func newFrozenFrameStats(endNS uint64, durationNS float64) frozenFrameStats {
 // nodeStackIfValid returns the nodeStack if we consider it valid as
 // a frame drop cause.
 func (s *frozenFrameStats) IsNodeStackValid(ns *nodeStack) bool {
-	return s.startNS <= ns.n.StartNS &&
+	return ns.n.StartNS >= s.startNS &&
 		ns.n.EndNS <= s.endNS &&
-		s.minDurationNS <= s.durationNS &&
+		ns.n.DurationNS >= s.minDurationNS &&
 		ns.n.StartNS <= s.startLimitNS &&
 		ns.n.IsApplication
 }


### PR DESCRIPTION
We were not comparing the minimum duration to the duration of the frame so it was never checking for this criteria.