### PR TITLE
chore: Return 502 from health endpoint on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Rename the frame drop issue title. ([#315](https://github.com/getsentry/vroom/pull/315))
 - Add new endpoint for regressed functions. ([#318](https://github.com/getsentry/vroom/pull/318))
+- Return 502 from health endpoint on shutdown. ([#323](https://github.com/getsentry/vroom/pull/323))
 
 ## 23.9.1
 

--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -225,7 +225,11 @@ func main() {
 }
 
 func (e *environment) getHealth(w http.ResponseWriter, _ *http.Request) {
-	w.WriteHeader(http.StatusNoContent)
+	if _, err := os.Stat("/tmp/vroom.down"); err == nil {
+		w.WriteHeader(http.StatusNoContent)
+	} else {
+		w.WriteHeader(http.StatusBadGateway)
+	}
 }
 
 type Filter struct {


### PR DESCRIPTION
On shutdown, there will be a file at `/tmp/vroom.down`. When this file exists, it's a sign that the pod will shutdown. So return 502 from the health endpoint.