### PR TITLE
fix(cocoa): Mark sentry frames as system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Close remaining open events in Android profiles. ([#316](https://github.com/getsentry/vroom/pull/316))
 - Enforce minimum frame duration for frame drop issue. ([#319](https://github.com/getsentry/vroom/pull/319))
+- Mark sentry frames as system frames when it's dynamically linked. ([#325](https://github.com/getsentry/vroom/pull/325))
 
 **Internal**
 

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -16,6 +16,9 @@ import (
 var (
 	windowsPathRegex      = regexp.MustCompile(`(?i)^([a-z]:\\|\\\\)`)
 	packageExtensionRegex = regexp.MustCompile(`\.(dylib|so|a|dll|exe)$`)
+	cocoaSystemPackage    = map[string]struct{}{
+		"Sentry": {},
+	}
 )
 
 type (
@@ -160,6 +163,13 @@ func (f Frame) IsCocoaApplicationFrame() bool {
 		// as a system frame as it does not contain any user code
 		return false
 	}
+
+	// Some packages are known to be system packages.
+	// If we detect them, mark them as a system frame immediately.
+	if _, exists := cocoaSystemPackage[f.ModuleOrPackage()]; exists {
+		return false
+	}
+
 	return packageutil.IsCocoaApplicationPackage(f.Package)
 }
 

--- a/internal/frame/frame_test.go
+++ b/internal/frame/frame_test.go
@@ -47,6 +47,14 @@ func TestIsCocoaApplicationFrame(t *testing.T) {
 			},
 			isApplication: true,
 		},
+		{
+			name: "symbolicate_internal",
+			frame: Frame{
+				Function: "symbolicate_internal",
+				Package:  "/private/var/containers/Bundle/Application/00000000-0000-0000-0000-000000000000/App.app/Frameworks/Sentry.framework/Sentry",
+			},
+			isApplication: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Sentry frames are known to be a system frame. So if they're detected, make sure they're not marked as an application frame.