### PR TITLE
fix(healthcheck): return 200 on /health ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Rename the frame drop issue title. ([#315](https://github.com/getsentry/vroom/pull/315))
 - Add new endpoint for regressed functions. ([#318](https://github.com/getsentry/vroom/pull/318))
 - Return 502 from health endpoint on shutdown. ([#323](https://github.com/getsentry/vroom/pull/323)), ([#324](https://github.com/getsentry/vroom/pull/324))
+- Health endpoint returns 200 instead of 204 on success ([#326](https://github.com/getsentry/vroom/pull/326))
 
 
 ## 23.9.1

--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -226,7 +226,7 @@ func main() {
 
 func (e *environment) getHealth(w http.ResponseWriter, _ *http.Request) {
 	if _, err := os.Stat("/tmp/vroom.down"); err != nil {
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
 	} else {
 		w.WriteHeader(http.StatusBadGateway)
 	}


### PR DESCRIPTION
Traffic Director requires a 200 response to consider a service healthy (20X doesn't count for some reason)