### PR TITLE
fix: add new cocoa symbol to search for for JSON issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Enforce minimum frame duration for frame drop issue. ([#319](https://github.com/getsentry/vroom/pull/319))
 - Mark sentry frames as system frames when it's dynamically linked. ([#325](https://github.com/getsentry/vroom/pull/325))
 - Do not return an occurrence for unknown function or when the stack is filled with them. ([#328](https://github.com/getsentry/vroom/pull/328))
+- Add more Cocoa symbols for profiling issue detectors ([#336](https://github.com/getsentry/vroom/pull/336))
 
 **Internal**
 

--- a/internal/occurrence/detect_frame.go
+++ b/internal/occurrence/detect_frame.go
@@ -360,6 +360,7 @@ var detectFrameJobs = map[platform.Platform][]DetectFrameOptions{
 					"ViewRendererHost.updateViewGraph<A>(body: (ViewGraph))":             ViewUpdate,
 				},
 				"UIKit": {
+					"-[_UIPathLazyImageAsset imageWithConfiguration:]": ImageDecode,
 					"-[UINib instantiateWithOwner:options:]": ViewInflation,
 				},
 			},

--- a/internal/occurrence/detect_frame.go
+++ b/internal/occurrence/detect_frame.go
@@ -283,6 +283,7 @@ var detectFrameJobs = map[platform.Platform][]DetectFrameOptions{
 					"JSONDecoder.decode<A>(_: A.Type, from: Any)":                                           JSONDecode,
 					"JSONDecoder.decode<A>(_: A.Type, from: Data)":                                          JSONDecode,
 					"JSONDecoder.decode<A>(_: A.Type, jsonData: Data, logErrors: Bool)":                     JSONDecode,
+					"-[_NSJSONReader parseData:options:error:]":                                             JSONEncode,
 					"JSONEncoder.encode<A>(A)":                                                              JSONEncode,
 					"NSFileManager.contents(atURL: URL)":                                                    FileRead,
 				},

--- a/internal/occurrence/detect_frame.go
+++ b/internal/occurrence/detect_frame.go
@@ -361,7 +361,7 @@ var detectFrameJobs = map[platform.Platform][]DetectFrameOptions{
 				},
 				"UIKit": {
 					"-[_UIPathLazyImageAsset imageWithConfiguration:]": ImageDecode,
-					"-[UINib instantiateWithOwner:options:]": ViewInflation,
+					"-[UINib instantiateWithOwner:options:]":           ViewInflation,
 				},
 			},
 		},


### PR DESCRIPTION
I tried generating a JSON on Main Thread issue for the iOS SE demo app, but saw that it took a codepath through a system call we don't currently search for: 
![image](https://github.com/getsentry/vroom/assets/3241469/5b4d67b4-7629-43f4-a0f7-51af263a4a3c)