### PR TITLE
fix: make android samples monotonic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+**Features**
+
+
+**Bug Fixes**
+- Turn non-monotonic samples wall-clock time into monotonic. ([#337](https://github.com/getsentry/vroom/pull/337))
+
+**Internal**
+
+
 ## 23.10.0
 
 **Features**

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -234,8 +234,6 @@ func (p *Android) FixSamplesTime() {
 
 // CallTrees generates call trees for a given profile.
 func (p Android) CallTrees() map[uint64][]*nodetree.Node {
-	// in case wall-clock.secs is not monotonic, "fix" it
-	p.FixSamplesTime()
 	var activeThreadID uint64
 	for _, thread := range p.Threads {
 		if thread.Name == mainThread {
@@ -374,8 +372,6 @@ func (p *Android) NormalizeMethods(pi profileInterface) {
 }
 
 func (p Android) Speedscope() (speedscope.Output, error) {
-	// in case wall-clock.secs is not monotonic, "fix" it
-	p.FixSamplesTime()
 	frames := make([]speedscope.Frame, 0)
 	methodIDToFrameIndex := make(map[uint64][]int)
 	for _, method := range p.Methods {

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -205,6 +205,9 @@ func getAdjustedTime(maxSecs, latest, current uint64) uint64 {
 // This is just a workaround to mitigate this issue, should it
 // happen.
 func (p *Android) FixSamplesTime() {
+	if p.Clock == GlobalClock || p.Clock == CPUClock {
+		return
+	}
 	threadMaxSecs := make(map[uint64]uint64)
 	threadLatestSampleTime := make(map[uint64]uint64)
 	var regression bool

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -206,25 +206,25 @@ func getAdjustedTime(maxSecs, latest, current uint64) uint64 {
 // happen.
 func (p *Android) FixSamplesTime() {
 	threadMaxSecs := make(map[uint64]uint64)
-	threadLatest := make(map[uint64]uint64)
+	threadLatestSampleTime := make(map[uint64]uint64)
 	var regression bool
 
 	for i, event := range p.Events {
 		current := event.Time.Monotonic.Wall.Secs
-		if current < threadLatest[event.ThreadID] {
+		if current < threadLatestSampleTime[event.ThreadID] {
 			regression = true
 		}
 
 		if regression {
-			newSec := getAdjustedTime(threadMaxSecs[event.ThreadID], threadLatest[event.ThreadID], current)
+			newSec := getAdjustedTime(threadMaxSecs[event.ThreadID], threadLatestSampleTime[event.ThreadID], current)
 			threadMaxSecs[event.ThreadID] = uint64Max(threadMaxSecs[event.ThreadID], newSec)
 
-			threadLatest[event.ThreadID] = current
+			threadLatestSampleTime[event.ThreadID] = current
 			p.Events[i].Time.Monotonic.Wall.Secs = newSec
 			continue
 		}
 
-		threadLatest[event.ThreadID] = current
+		threadLatestSampleTime[event.ThreadID] = current
 		threadMaxSecs[event.ThreadID] = uint64Max(threadMaxSecs[event.ThreadID], current)
 	}
 }

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -200,7 +200,7 @@ func getAdjustedTime(maxSecs, latest, current uint64) uint64 {
 // Wall-clock time is supposed to be monotonic
 // in a few rare cases we've noticed this was not the case.
 // Due to some overflow happening client-side in the embedded
-// profile, the sequence might be decreasing at certain points.
+// profiler, the sequence might be decreasing at certain points.
 //
 // This is just a workaround to mitigate this issue, should it
 // happen.

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -180,13 +180,6 @@ func (p Android) TimestampGetter() func(EventTime) uint64 {
 	return buildTimestamp
 }
 
-func uint64Max(a, b uint64) uint64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // maxSecs: the highest timestamp/secs in the sequence so far
 // latest: the latest time value (at time t-1) before it was updated
 // current: current value (at time t) before it's updated
@@ -220,7 +213,7 @@ func (p *Android) FixSamplesTime() {
 
 		if regression {
 			newSec := getAdjustedTime(threadMaxSecs[event.ThreadID], threadLatestSampleTime[event.ThreadID], current)
-			threadMaxSecs[event.ThreadID] = uint64Max(threadMaxSecs[event.ThreadID], newSec)
+			threadMaxSecs[event.ThreadID] = max(threadMaxSecs[event.ThreadID], newSec)
 
 			threadLatestSampleTime[event.ThreadID] = current
 			p.Events[i].Time.Monotonic.Wall.Secs = newSec
@@ -228,7 +221,7 @@ func (p *Android) FixSamplesTime() {
 		}
 
 		threadLatestSampleTime[event.ThreadID] = current
-		threadMaxSecs[event.ThreadID] = uint64Max(threadMaxSecs[event.ThreadID], current)
+		threadMaxSecs[event.ThreadID] = max(threadMaxSecs[event.ThreadID], current)
 	}
 }
 

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -203,21 +203,19 @@ func (p *Android) FixSamplesTime() {
 	}
 	threadMaxTimeNs := make(map[uint64]uint64)
 	threadLatestSampleTimeNs := make(map[uint64]uint64)
-	regression := false
-	regressionIndex := 0
+	regressionIndex := -1
 
 	for i, event := range p.Events {
 		current := (event.Time.Monotonic.Wall.Secs * 1e9) + event.Time.Monotonic.Wall.Nanos
 		if current < threadLatestSampleTimeNs[event.ThreadID] {
 			regressionIndex = i
-			regression = true
 			break
 		}
 		threadLatestSampleTimeNs[event.ThreadID] = current
 		threadMaxTimeNs[event.ThreadID] = max(threadMaxTimeNs[event.ThreadID], current)
 	}
 
-	if regression {
+	if regressionIndex > 0 {
 		for i := regressionIndex; i < len(p.Events); i++ {
 			event := p.Events[i]
 			current := (event.Time.Monotonic.Wall.Secs * 1e9) + event.Time.Monotonic.Wall.Nanos

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -187,12 +187,12 @@ func uint64Max(a, b uint64) uint64 {
 	return b
 }
 
+// maxSecs: the highest timestamp/secs in the sequence so far
+// latest: the latest time value (at time t-1) before it was updated
+// current: current value (at time t) before it's updated
 func getAdjustedTime(maxSecs, latest, current uint64) uint64 {
-	if current < maxSecs {
-		if current < latest {
-			return maxSecs + 1
-		}
-		return maxSecs + (current - latest)
+	if current < maxSecs && current < latest {
+		return maxSecs + 1
 	}
 	return maxSecs + (current - latest)
 }

--- a/internal/profile/android_test.go
+++ b/internal/profile/android_test.go
@@ -635,7 +635,7 @@ func TestFixSamplesTime(t *testing.T) {
 							Monotonic: EventMonotonic{
 								Wall: Duration{
 									Secs:  8,
-									Nanos: 3000,
+									Nanos: 2000,
 								},
 							},
 						},
@@ -648,7 +648,7 @@ func TestFixSamplesTime(t *testing.T) {
 							Monotonic: EventMonotonic{
 								Wall: Duration{
 									Secs:  8,
-									Nanos: 3000,
+									Nanos: 2000,
 								},
 							},
 						},
@@ -661,7 +661,7 @@ func TestFixSamplesTime(t *testing.T) {
 							Monotonic: EventMonotonic{
 								Wall: Duration{
 									Secs:  11,
-									Nanos: 3000,
+									Nanos: 2000,
 								},
 							},
 						},

--- a/internal/profile/android_test.go
+++ b/internal/profile/android_test.go
@@ -291,12 +291,68 @@ var (
 					},
 				},
 			},
+			{
+				Action:   "Enter",
+				ThreadID: 2,
+				MethodID: 1,
+				Time: EventTime{
+					Monotonic: EventMonotonic{
+						Wall: Duration{
+							Secs:  1,
+							Nanos: 3000,
+						},
+					},
+				},
+			},
+			{
+				Action:   "Enter",
+				ThreadID: 2,
+				MethodID: 2,
+				Time: EventTime{
+					Monotonic: EventMonotonic{
+						Wall: Duration{
+							Secs:  2,
+							Nanos: 3000,
+						},
+					},
+				},
+			},
+			{
+				Action:   "Exit",
+				ThreadID: 2,
+				MethodID: 2,
+				Time: EventTime{
+					Monotonic: EventMonotonic{
+						Wall: Duration{
+							Secs:  2,
+							Nanos: 3000,
+						},
+					},
+				},
+			},
+			{
+				Action:   "Exit",
+				ThreadID: 2,
+				MethodID: 1,
+				Time: EventTime{
+					Monotonic: EventMonotonic{
+						Wall: Duration{
+							Secs:  3,
+							Nanos: 3000,
+						},
+					},
+				},
+			},
 		},
 		StartTime: 398635355383000,
 		Threads: []AndroidThread{
 			{
 				ID:   1,
 				Name: "main",
+			},
+			{
+				ID:   2,
+				Name: "background",
 			},
 		},
 	}
@@ -610,12 +666,68 @@ func TestFixSamplesTime(t *testing.T) {
 							},
 						},
 					},
+					{
+						Action:   "Enter",
+						ThreadID: 2,
+						MethodID: 1,
+						Time: EventTime{
+							Monotonic: EventMonotonic{
+								Wall: Duration{
+									Secs:  1,
+									Nanos: 3000,
+								},
+							},
+						},
+					},
+					{
+						Action:   "Enter",
+						ThreadID: 2,
+						MethodID: 2,
+						Time: EventTime{
+							Monotonic: EventMonotonic{
+								Wall: Duration{
+									Secs:  2,
+									Nanos: 3000,
+								},
+							},
+						},
+					},
+					{
+						Action:   "Exit",
+						ThreadID: 2,
+						MethodID: 2,
+						Time: EventTime{
+							Monotonic: EventMonotonic{
+								Wall: Duration{
+									Secs:  2,
+									Nanos: 3000,
+								},
+							},
+						},
+					},
+					{
+						Action:   "Exit",
+						ThreadID: 2,
+						MethodID: 1,
+						Time: EventTime{
+							Monotonic: EventMonotonic{
+								Wall: Duration{
+									Secs:  3,
+									Nanos: 3000,
+								},
+							},
+						},
+					},
 				},
 				StartTime: 398635355383000,
 				Threads: []AndroidThread{
 					{
 						ID:   1,
 						Name: "main",
+					},
+					{
+						ID:   2,
+						Name: "background",
 					},
 				},
 			},

--- a/internal/profile/legacy.go
+++ b/internal/profile/legacy.go
@@ -239,6 +239,8 @@ func (p *LegacyProfile) Normalize() {
 		t.ReplaceIdleStacks()
 	case *Android:
 		t.NormalizeMethods(p)
+		// in case wall-clock.secs is not monotonic, "fix" it
+		t.FixSamplesTime()
 	}
 
 	if p.BuildID != "" {


### PR DESCRIPTION
Wall-clock time is supposed to be monotonic. In a few rare cases we've noticed this was not the case.

Due to some overflow happening client-side in the embedded profiler, the sequence might be decreasing at certain points.

This is just a workaround to mitigate this issue (at rendering time) and avoid a front-end crash, should it happen.