### PR TITLE
deps: update docker image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,13 @@ updates:
       interval: "daily"
     # security updates only
     open-pull-requests-limit: 0
+
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
-    # security updates only
-    open-pull-requests-limit: 0
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    # security updates only
-    open-pull-requests-limit: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,15 @@
 
 **Features**
 
+- Update base Docker image to Debian 12. ([#340](https://github.com/getsentry/vroom/pull/340))
 
 **Bug Fixes**
+
 - Turn non-monotonic samples wall-clock time into monotonic. ([#337](https://github.com/getsentry/vroom/pull/337))
 
 **Internal**
 
 - Move FixSamplesTime call to speedscope and calltrees methods([#339](https://github.com/getsentry/vroom/pull/339))
-
 
 ## 23.10.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o . -ldflags="-s -w -X main.release=$(git rev-parse HEAD)" ./cmd/vroom
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 EXPOSE 8080
 


### PR DESCRIPTION
- update the docker image to debian 12
- configure dependabot for all updates on docker images and github actions

Should address most of #338 