### PR TITLE
feat(python): Always classify sentry_sdk as system frame

### DIFF
--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -195,6 +195,15 @@ func (f Frame) IsPythonApplicationFrame() bool {
 	}
 
 	module := strings.SplitN(f.Module, ".", 2)
+
+	// It's possible that users do not install packages
+	// into one of the default paths. In this case, we
+	// should try to classify the sdk as a system frame
+	// at least to minimum false classification.
+	if module[0] == "sentry_sdk" {
+		return false
+	}
+
 	_, ok := pythonStdlib[module[0]]
 	return !ok
 }

--- a/internal/frame/frame_test.go
+++ b/internal/frame/frame_test.go
@@ -134,6 +134,13 @@ func TestIsPythonApplicationFrame(t *testing.T) {
 			},
 			isApplication: false,
 		},
+		{
+			name: "sentry_sdk",
+			frame: Frame{
+				Module: "sentry_sdk.profiler",
+			},
+			isApplication: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
It's possible that users do not install packages into one of the default paths. In this case, we should try to classify the sdk as a system frame to minimze false classification.