### PR TITLE
chore(stats-detectors): Update regression issue subtitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add payload type to occurrence payloads. ([#351](https://github.com/getsentry/vroom/pull/351))
 - Always classify sentry_sdk as system frame. ([#357](https://github.com/getsentry/vroom/pull/357))
+- Update regression issue subtitle. ([#358](https://github.com/getsentry/vroom/pull/358))
 
 **Internal**:
 

--- a/internal/occurrence/occurrence.go
+++ b/internal/occurrence/occurrence.go
@@ -218,12 +218,6 @@ func FromRegressedFunction(
 	fingerprint := fmt.Sprintf("%x", regressed.Fingerprint)
 	beforeP95 := time.Duration(regressed.AggregateRange1).Round(10 * time.Microsecond)
 	afterP95 := time.Duration(regressed.AggregateRange2).Round(10 * time.Microsecond)
-	regressionText := fmt.Sprintf(
-		"%s increased from %s to %s.",
-		fullyQualifiedName,
-		beforeP95,
-		afterP95,
-	)
 
 	occurrenceType := FrameRegressionExpType
 	var issueTitle IssueTitle = "Function Duration Regression (Experimental)"
@@ -272,7 +266,12 @@ func FromRegressedFunction(
 			{
 				Important: true,
 				Name:      EvidenceRegression,
-				Value:     regressionText,
+				Value: fmt.Sprintf(
+					"%s duration increased from %s to %s (P95).",
+					fullyQualifiedName,
+					beforeP95,
+					afterP95,
+				),
 			},
 			{
 				Name:  EvidenceBreakpoint,
@@ -289,8 +288,12 @@ func FromRegressedFunction(
 		Level:       "info",
 		PayloadType: OccurrencePayload,
 		ProjectID:   regressed.ProjectID,
-		Subtitle:    regressionText,
-		Type:        occurrenceType,
+		Subtitle: fmt.Sprintf(
+			"Duration increased from %s to %s (P95).",
+			beforeP95,
+			afterP95,
+		),
+		Type: occurrenceType,
 	}
 }
 

--- a/internal/occurrence/occurrence_test.go
+++ b/internal/occurrence/occurrence_test.go
@@ -68,7 +68,7 @@ func TestFromRegressedFunction(t *testing.T) {
 			},
 			expectedType:     2011,
 			expectedTitle:    "Function Regression",
-			expectedSubtitle: "foo.bar increased from 100ms to 200ms.",
+			expectedSubtitle: "Duration increased from 100ms to 200ms (P95).",
 		},
 		{
 			name:  "unreleased",
@@ -84,7 +84,7 @@ func TestFromRegressedFunction(t *testing.T) {
 			},
 			expectedType:     2010,
 			expectedTitle:    "Function Duration Regression (Experimental)",
-			expectedSubtitle: "foo.bar increased from 100ms to 200ms.",
+			expectedSubtitle: "Duration increased from 100ms to 200ms (P95).",
 		},
 	}
 


### PR DESCRIPTION
The subtitle appears in the issue details but the slack previews supposedly use the important evidence display.