### PR TITLE
enhance: add frame-level platform field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Support released key on regressed functions ([#355](https://github.com/getsentry/vroom/pull/355))
+- Add frame-level platform field ([#364](https://github.com/getsentry/vroom/pull/364))
 
 **Bug Fixes**:
 

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -39,7 +39,7 @@ type (
 		Status          string `json:"status,omitempty"`
 		SymAddr         string `json:"sym_addr,omitempty"`
 		Symbol          string `json:"symbol,omitempty"`
-		Patform         string `json:"platform,omitempty"`
+		Platform        string `json:"platform,omitempty"`
 	}
 
 	Data struct {

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -39,6 +39,7 @@ type (
 		Status          string `json:"status,omitempty"`
 		SymAddr         string `json:"sym_addr,omitempty"`
 		Symbol          string `json:"symbol,omitempty"`
+		Patform         string `json:"platform,omitempty"`
 	}
 
 	Data struct {


### PR DESCRIPTION
React-native sends mixed list of frames (Js and cocoa) with a platform field to help discern between those 2
