### PR TITLE
feat(stats-detectors): Return emitted functions in response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 **Features**:
 
 - Relicense under FSL-1.0-Apache-2.0. ([#366](https://github.com/getsentry/vroom/pull/366))
+- Return the emitted regressions in response. ([#372](https://github.com/getsentry/vroom/pull/372))
+
 
 **Bug Fixes**:
 

--- a/cmd/vroom/regressed.go
+++ b/cmd/vroom/regressed.go
@@ -20,6 +20,7 @@ func (env *environment) postRegressed(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	emitted := []occurrence.RegressedFunction{}
 	occurrences := []*occurrence.Occurrence{}
 	for _, regressedFunction := range regressedFunctions {
 		s := sentry.StartSpan(ctx, "processing")
@@ -32,13 +33,15 @@ func (env *environment) postRegressed(w http.ResponseWriter, r *http.Request) {
 		} else if occurrence == nil {
 			continue
 		}
+		emitted = append(emitted, regressedFunction)
 		occurrences = append(occurrences, occurrence)
 	}
 
 	s := sentry.StartSpan(ctx, "json.marshal")
 	data := struct {
-		Occurrences int `json:"occurrences"`
-	}{Occurrences: len(occurrences)}
+		Occurrences int                            `json:"occurrences"`
+		Emitted     []occurrence.RegressedFunction `json:"emitted"`
+	}{Occurrences: len(occurrences), Emitted: emitted}
 	b, err := json.Marshal(data)
 	s.Finish()
 	if err != nil {


### PR DESCRIPTION
We want to start tracking which were emitted so return exactly which was emitted to make this possible.