### PR TITLE
chore(gocd): Bumping gocd-jsonnet version

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.3.1"
+      "version": "v2.7"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "cfd0a0c54a580e1932e14368d0c99b2b5013c434",
-      "sum": "SFeCD13Z2qQftwrjVAKE19IjjgJAk8ninSJwePKhI8A="
+      "version": "97af8955747da4f68ce4f70a5128b4e53956e9b2",
+      "sum": "qQiTUU6BkUbKBGblpBppxFBewhIqqQaWlz01ZTGEpi4="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Bumping to v2.7 of gocd-jsonnet which removes customer-5 as we are getting rid of it.

#skip-changelog