### PR TITLE
feat(gocd): enable vroom deploys to DE region

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.7"
+      "version": "v2.8"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "97af8955747da4f68ce4f70a5128b4e53956e9b2",
-      "sum": "qQiTUU6BkUbKBGblpBppxFBewhIqqQaWlz01ZTGEpi4="
+      "version": "172de74e6347127957707d990f20f3e99c6c1c46",
+      "sum": "pBB9Jio0EnAgB7811tnly/S1B5fz6BeYoi4hQ7KgsHM="
     }
   ],
   "legacyImports": false

--- a/gocd/templates/vroom.jsonnet
+++ b/gocd/templates/vroom.jsonnet
@@ -3,6 +3,13 @@ local pipedream = import 'github.com/getsentry/gocd-jsonnet/libs/pipedream.libso
 
 local pipedream_config = {
   name: 'vroom',
+  exclude_regions: [
+    'customer-1',
+    'customer-2',
+    'customer-3',
+    'customer-4',
+    'customer-6',
+  ],
   materials: {
     vroom_repo: {
       git: 'git@github.com:getsentry/vroom.git',

--- a/gocd/templates/vroom.jsonnet
+++ b/gocd/templates/vroom.jsonnet
@@ -3,13 +3,6 @@ local pipedream = import 'github.com/getsentry/gocd-jsonnet/libs/pipedream.libso
 
 local pipedream_config = {
   name: 'vroom',
-  exclude_regions: [
-    'customer-1',
-    'customer-2',
-    'customer-3',
-    'customer-4',
-    'customer-6',
-  ],
   materials: {
     vroom_repo: {
       git: 'git@github.com:getsentry/vroom.git',


### PR DESCRIPTION
This bumps the gocd library version so deploys go out to the `de` region as well.

#skip-changelog