### PR TITLE
ref: serialize speedscope.Frame Col field as `colno` in order to align it with the Column field of the frame.Frame struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Bump trufflesecurity/trufflehog from 3.68.5 to 3.69.0 ([#421](https://github.com/getsentry/vroom/pull/421))
 - Keep col info when converting from android method to frame ([#423](https://github.com/getsentry/vroom/pull/423))
 - Bump google.golang.org/protobuf from 1.30.0 to 1.33.0 ([#427](https://github.com/getsentry/vroom/pull/427))
+- Serialize speedscope.Frame Col field as colno in order to align it with the Column field of the frame.Frame struct ([#428](https://github.com/getsentry/vroom/pull/428))
 
 ## 23.12.0
 

--- a/internal/speedscope/speedscope.go
+++ b/internal/speedscope/speedscope.go
@@ -25,7 +25,7 @@ const (
 
 type (
 	Frame struct {
-		Col           uint32 `json:"col,omitempty"`
+		Col           uint32 `json:"colno,omitempty"`
 		File          string `json:"file,omitempty"`
 		Image         string `json:"image,omitempty"`
 		Inline        bool   `json:"inline,omitempty"`


### PR DESCRIPTION
This way both the frames returned from Android speedscope and the frames returned from the sample profiles will have a `colno` json field that can be used in the flamechart/flamegraph visualization


