### PR TITLE
fix(android): Enters/exits are per thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Label all node frames as system ([#392](https://github.com/getsentry/vroom/pull/392))
 - Fix react-native (android) rendering issue ([#397](https://github.com/getsentry/vroom/pull/397))
 - Restrict max depth for android profiles ([#424](https://github.com/getsentry/vroom/pull/424)), ([#426](https://github.com/getsentry/vroom/pull/426))
+- Android enter/exit checks should be per thread ([#429](https://github.com/getsentry/vroom/pull/429))
 
 **Internal**:
 


### PR DESCRIPTION
The enters/exits should've been counted per thread. This was working previously because the enters/exists across thread somehow added up in these bad examples, and the change to skip frames past a stack depth surfaced this issue.