### PR TITLE
feat: add support to ingest metric_summaries for profile functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add callTree generation for reactnative (android+js) profiles ([#390](https://github.com/getsentry/vroom/pull/390))
 - Use profiles that were not dynamically sampled to enhance slowest functions aggregation ([#300](https://github.com/getsentry/vroom/pull/300))
 - Add support for writing function metrics to generic metrics platform ([#422](https://github.com/getsentry/vroom/pull/422))
+- Add support to ingest metric_summaries for profile functions ([#431](https://github.com/getsentry/vroom/pull/431))
 
 **Bug Fixes**:
 

--- a/cmd/vroom/config.go
+++ b/cmd/vroom/config.go
@@ -10,6 +10,9 @@ type (
 		OccurrencesKafkaBrokers []string `env:"SENTRY_KAFKA_BROKERS_OCCURRENCES" env-default:"localhost:9092"`
 		OccurrencesKafkaTopic   string   `env:"SENTRY_KAFKA_TOPIC_OCCURRENCES"   env-default:"ingest-occurrences"`
 
+		SpansKafkaBrokers        []string `env:"SENTRY_KAFKA_BROKERS_SPANS" env-default:"localhost:9092"`
+		MetricsSummaryKafkaTopic string   `env:"SENTRY_KAFKA_TOPIC_METRICS_SUMMARY"   env-default:"snuba-metrics-summaries"`
+
 		ProfilingKafkaBrokers []string `env:"SENTRY_KAFKA_BROKERS_PROFILING" env-default:"localhost:9092"`
 		CallTreesKafkaTopic   string   `env:"SENTRY_KAFKA_TOPIC_CALL_TREES"  env-default:"profiles-call-tree"`
 		ProfilesKafkaTopic    string   `env:"SENTRY_KAKFA_TOPIC_PROFILES"    env-default:"processed-profiles"`

--- a/cmd/vroom/kafka.go
+++ b/cmd/vroom/kafka.go
@@ -127,7 +127,8 @@ func generateMetricSummariesKafkaMessageBatch(p *profile.Profile, metrics []sent
 	messages := make([]kafka.Message, 0, len(metrics))
 	for i, metric := range metrics {
 		// add profile_id to the metrics_summary tags
-		metric.GetTags()["profile_id"] = p.ID()
+		tags := metric.GetTags()
+		tags["profile_id"] = p.ID()
 		ms := MetricsSummaryKafkaMessage{
 			Count:         metricsSummary[i].Count,
 			DurationMs:    uint32(p.TransactionMetadata().TransactionEnd.UnixMilli() - p.TransactionMetadata().TransactionStart.UnixMilli()),
@@ -139,7 +140,7 @@ func generateMetricSummariesKafkaMessageBatch(p *profile.Profile, metrics []sent
 			ProjectID:     p.ProjectID(),
 			Received:      p.Received().Unix(),
 			RetentionDays: p.RetentionDays(),
-			Tags:          metric.GetTags(),
+			Tags:          tags,
 			TraceID:       p.Transaction().TraceID,
 			// currently we need to set this to a randomly generated span_id because
 			// the metrics_summaries dataset is defined with a ReplaceMergingTree engine

--- a/cmd/vroom/kafka.go
+++ b/cmd/vroom/kafka.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/getsentry/sentry-go"
 	"github.com/getsentry/vroom/internal/nodetree"
 	"github.com/getsentry/vroom/internal/platform"
 	"github.com/getsentry/vroom/internal/profile"
+	"github.com/segmentio/kafka-go"
 )
 
 type (
@@ -45,6 +53,26 @@ type (
 		TransactionName      string            `json:"transaction_name"`
 		VersionCode          string            `json:"version_code"`
 		VersionName          string            `json:"version_name"`
+	}
+
+	// MetricsSummaryKafkaMessage is representing the struct we send to Kafka to insert Metrics Summary in ClickHouse.
+	MetricsSummaryKafkaMessage struct {
+		Count         uint64            `json:"count"`
+		DurationMs    uint32            `json:"duration_ms"`
+		EndTimestamp  float64           `json:"end_timestamp"`
+		Group         string            `json:"group"`
+		IsSegment     bool              `json:"is_segment"`
+		Max           float64           `json:"max"`
+		Min           float64           `json:"min"`
+		Sum           float64           `json:"sum"`
+		Mri           string            `json:"mri"`
+		ProjectID     uint64            `json:"project_id"`
+		Received      int64             `json:"received"`
+		RetentionDays int               `json:"retention_days"`
+		SegmentID     string            `json:"segment_id"`
+		SpanID        string            `json:"span_id"`
+		Tags          map[string]string `json:"tags"`
+		TraceID       string            `json:"trace_id"`
 	}
 )
 
@@ -90,4 +118,50 @@ func buildProfileKafkaMessage(p profile.Profile) ProfileKafkaMessage {
 		VersionCode:          m.VersionCode,
 		VersionName:          m.VersionName,
 	}
+}
+
+func generateMetricSummariesKafkaMessageBatch(p *profile.Profile, metrics []sentry.Metric, metricsSummary []MetricSummary) ([]kafka.Message, error) {
+	if len(metrics) != len(metricsSummary) {
+		return nil, fmt.Errorf("len(metrics): %d - len(metrics_summary): %d", len(metrics), len(metricsSummary))
+	}
+	messages := make([]kafka.Message, 0, len(metrics))
+	for i, metric := range metrics {
+		// add profile_id to the metrics_summary tags
+		metric.GetTags()["profile_id"] = p.ID()
+		ms := MetricsSummaryKafkaMessage{
+			Count:         metricsSummary[i].Count,
+			DurationMs:    uint32(p.TransactionMetadata().TransactionEnd.UnixMilli() - p.TransactionMetadata().TransactionStart.UnixMilli()),
+			EndTimestamp:  float64(p.TransactionMetadata().TransactionEnd.Unix()),
+			Max:           metricsSummary[i].Max,
+			Min:           metricsSummary[i].Min,
+			Sum:           metricsSummary[i].Sum,
+			Mri:           "d:profiles/function.duration@millisecond",
+			ProjectID:     p.ProjectID(),
+			Received:      p.Received().Unix(),
+			RetentionDays: p.RetentionDays(),
+			Tags:          metric.GetTags(),
+			TraceID:       p.Transaction().TraceID,
+			// currently we need to set this to a randomly generated span_id because
+			// the metrics_summaries dataset is defined with a ReplaceMergingTree engine
+			// and given its ORDER BY definition we would not be able to store samples
+			// with the same span_id.
+			// see: https://github.com/getsentry/snuba/blob/master/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py#L44-L45
+			//
+			// That's ok for our use case as we currently don't need span_id for profile function,
+			// but, once we'll recreate the table and get rid of the ReplaceMergineTree
+			// we can set it back to p.Transaction().SegmentID for the sake of consistency
+			SpanID:    strings.Replace(uuid.New().String(), "-", "", -1)[16:],
+			IsSegment: true,
+			SegmentID: p.Transaction().SegmentID,
+		}
+		b, err := json.Marshal(ms)
+		if err != nil {
+			return nil, err
+		}
+		msg := kafka.Message{
+			Value: b,
+		}
+		messages = append(messages, msg)
+	}
+	return messages, nil
 }

--- a/cmd/vroom/kafka.go
+++ b/cmd/vroom/kafka.go
@@ -14,6 +14,8 @@ import (
 	"github.com/segmentio/kafka-go"
 )
 
+const profilesFunctionMri = "d:profiles/function.duration@millisecond"
+
 type (
 	// FunctionsKafkaMessage is representing the struct we send to Kafka to insert functions in ClickHouse.
 	FunctionsKafkaMessage struct {
@@ -136,7 +138,7 @@ func generateMetricSummariesKafkaMessageBatch(p *profile.Profile, metrics []sent
 			Max:           metricsSummary[i].Max,
 			Min:           metricsSummary[i].Min,
 			Sum:           metricsSummary[i].Sum,
-			Mri:           "d:profiles/function.duration@millisecond",
+			Mri:           profilesFunctionMri,
 			ProjectID:     p.ProjectID(),
 			Received:      p.Received().Unix(),
 			RetentionDays: p.RetentionDays(),

--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -35,8 +35,9 @@ type environment struct {
 
 	snuba snubautil.Client
 
-	occurrencesWriter *kafka.Writer
-	profilingWriter   *kafka.Writer
+	occurrencesWriter   *kafka.Writer
+	profilingWriter     *kafka.Writer
+	metricSummaryWriter *kafka.Writer
 
 	storage *blob.Bucket
 }
@@ -83,6 +84,15 @@ func newEnvironment() (*environment, error) {
 		BatchSize:    10,
 		Compression:  kafka.Lz4,
 		ReadTimeout:  3 * time.Second,
+		WriteTimeout: 3 * time.Second,
+	}
+	e.metricSummaryWriter = &kafka.Writer{
+		Addr:         kafka.TCP(e.config.SpansKafkaBrokers...),
+		Async:        true,
+		Balancer:     kafka.CRC32Balancer{},
+		BatchSize:    100,
+		ReadTimeout:  3 * time.Second,
+		Topic:        e.config.MetricsSummaryKafkaTopic,
 		WriteTimeout: 3 * time.Second,
 	}
 	return &e, nil

--- a/cmd/vroom/utils.go
+++ b/cmd/vroom/utils.go
@@ -159,8 +159,9 @@ func getFlamegraphNumWorkers(numProfiles, minNumWorkers int) int {
 	return max(v, minNumWorkers)
 }
 
-func extractMetricsFromFunctions(p *profile.Profile, functions []nodetree.CallTreeFunction) []sentry.Metric {
+func extractMetricsFromFunctions(p *profile.Profile, functions []nodetree.CallTreeFunction) ([]sentry.Metric, []MetricSummary) {
 	metrics := make([]sentry.Metric, 0, len(functions))
+	metricsSummary := make([]MetricSummary, 0, len(functions))
 
 	for _, function := range functions {
 		if len(function.SelfTimesNS) == 0 {
@@ -180,14 +181,26 @@ func extractMetricsFromFunctions(p *profile.Profile, functions []nodetree.CallTr
 			"os_version":     p.Metadata().DeviceOSVersion,
 		}
 		duration := float64(function.SelfTimesNS[0] / 1e6)
+		summary := MetricSummary{
+			Min:   duration,
+			Max:   duration,
+			Sum:   duration,
+			Count: 1,
+		}
 		dm := sentry.NewDistributionMetric("profiles/function.duration", sentry.MilliSecond(), tags, p.Metadata().Timestamp, duration)
 		// loop remaining selfTime durations
 		for i := 1; i < len(function.SelfTimesNS); i++ {
-			dm.Add(float64(function.SelfTimesNS[i] / 1e6))
+			duration := float64(function.SelfTimesNS[i] / 1e6)
+			dm.Add(duration)
+			summary.Min = min(summary.Min, duration)
+			summary.Max = max(summary.Max, duration)
+			summary.Sum = summary.Sum + duration
+			summary.Count = summary.Count + 1
 		}
 		metrics = append(metrics, dm)
+		metricsSummary = append(metricsSummary, summary)
 	}
-	return metrics
+	return metrics, metricsSummary
 }
 
 func sendMetrics(p *profile.Profile, metrics []sentry.Metric) {
@@ -202,4 +215,11 @@ func sendMetrics(p *profile.Profile, metrics []sentry.Metric) {
 	})
 
 	tr.SendEvent(e)
+}
+
+type MetricSummary struct {
+	Min   float64
+	Max   float64
+	Sum   float64
+	Count uint64
 }

--- a/internal/profile/legacy.go
+++ b/internal/profile/legacy.go
@@ -260,6 +260,7 @@ func (p LegacyProfile) GetTransaction() transaction.Transaction {
 		ID:             p.TransactionID,
 		Name:           p.TransactionName,
 		TraceID:        p.TraceID,
+		SegmentID:      p.TransactionMetadata.SegmentID,
 	}
 }
 

--- a/internal/transaction/metadata.go
+++ b/internal/transaction/metadata.go
@@ -14,5 +14,6 @@ type (
 		TransactionOp     string    `json:"transaction.op,omitempty"`
 		TransactionStart  time.Time `json:"transaction.start"`
 		TransactionStatus string    `json:"transaction.status,omitempty"`
+		SegmentID         string    `json:"segment_id,omitempty"`
 	}
 )

--- a/internal/transaction/transaction.go
+++ b/internal/transaction/transaction.go
@@ -7,5 +7,6 @@ type (
 		ID             string `json:"id"`
 		Name           string `json:"name"`
 		TraceID        string `json:"trace_id"`
+		SegmentID      string `json:"segment_id"`
 	}
 )


### PR DESCRIPTION
More specifically, we'll ingest with the tags, among other things, the profile_id of the profile from which we extracted the function metric, so that we'll be able to fetch some samples when necessary.


Env. Vars. already set with PR https://github.com/getsentry/ops/pull/9698