### PR TITLE
fix: react native (with cocoa) profile normalization

### DIFF
--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -19,27 +19,28 @@ var (
 	javascriptSystemPackagePathRegexp = regexp.MustCompile(`node_modules|^(@moz-extension|chrome-extension)`)
 	cocoaSystemPackage                = map[string]struct{}{
 		"Sentry": {},
+		"hermes": {},
 	}
 )
 
 type (
 	Frame struct {
-		Column          uint32 `json:"colno,omitempty"`
-		Data            Data   `json:"data"`
-		File            string `json:"filename,omitempty"`
-		Function        string `json:"function,omitempty"`
-		InApp           *bool  `json:"in_app"`
-		InstructionAddr string `json:"instruction_addr,omitempty"`
-		Lang            string `json:"lang,omitempty"`
-		Line            uint32 `json:"lineno,omitempty"`
-		MethodID        uint64 `json:"-"`
-		Module          string `json:"module,omitempty"`
-		Package         string `json:"package,omitempty"`
-		Path            string `json:"abs_path,omitempty"`
-		Status          string `json:"status,omitempty"`
-		SymAddr         string `json:"sym_addr,omitempty"`
-		Symbol          string `json:"symbol,omitempty"`
-		Platform        string `json:"platform,omitempty"`
+		Column          uint32            `json:"colno,omitempty"`
+		Data            Data              `json:"data"`
+		File            string            `json:"filename,omitempty"`
+		Function        string            `json:"function,omitempty"`
+		InApp           *bool             `json:"in_app"`
+		InstructionAddr string            `json:"instruction_addr,omitempty"`
+		Lang            string            `json:"lang,omitempty"`
+		Line            uint32            `json:"lineno,omitempty"`
+		MethodID        uint64            `json:"-"`
+		Module          string            `json:"module,omitempty"`
+		Package         string            `json:"package,omitempty"`
+		Path            string            `json:"abs_path,omitempty"`
+		Status          string            `json:"status,omitempty"`
+		SymAddr         string            `json:"sym_addr,omitempty"`
+		Symbol          string            `json:"symbol,omitempty"`
+		Platform        platform.Platform `json:"platform,omitempty"`
 	}
 
 	Data struct {

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getsentry/vroom/internal/frame"
 	"github.com/getsentry/vroom/internal/nodetree"
 	"github.com/getsentry/vroom/internal/packageutil"
+	"github.com/getsentry/vroom/internal/platform"
 	"github.com/getsentry/vroom/internal/speedscope"
 )
 
@@ -23,17 +24,17 @@ type (
 	}
 
 	AndroidMethod struct {
-		ClassName    string          `json:"class_name,omitempty"`
-		Data         Data            `json:"data"`
-		ID           uint64          `json:"id,omitempty"`
-		InlineFrames []AndroidMethod `json:"inline_frames,omitempty"`
-		Name         string          `json:"name,omitempty"`
-		Signature    string          `json:"signature,omitempty"`
-		SourceFile   string          `json:"source_file,omitempty"`
-		SourceLine   uint32          `json:"source_line,omitempty"`
-		SourceCol    uint32          `json:"-"`
-		InApp        *bool           `json:"in_app"`
-		Platform     string          `json:"platform,omitempty"`
+		ClassName    string            `json:"class_name,omitempty"`
+		Data         Data              `json:"data"`
+		ID           uint64            `json:"id,omitempty"`
+		InlineFrames []AndroidMethod   `json:"inline_frames,omitempty"`
+		Name         string            `json:"name,omitempty"`
+		Signature    string            `json:"signature,omitempty"`
+		SourceFile   string            `json:"source_file,omitempty"`
+		SourceLine   uint32            `json:"source_line,omitempty"`
+		SourceCol    uint32            `json:"-"`
+		InApp        *bool             `json:"in_app"`
+		Platform     platform.Platform `json:"platform,omitempty"`
 	}
 
 	Data struct {

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -400,10 +400,18 @@ func (p *Profile) Speedscope() (speedscope.Output, error) {
 }
 
 func (p *Profile) IsApplicationFrame(f frame.Frame) bool {
-	if f.InApp != nil {
+	// for react-native the in_app field seems to be messed up most of the times,
+	// with system libraries and other frames that are clearly system frames
+	// labelled as `in_app`.
+	// This is likely because RN uses static libraries which are bundled into the app binary.
+	// When symbolicated they are marked in_app.
+	//
+	// For this reason, for react-native app (p.Platform != f.Platform), we skip the f.InApp!=nil
+	// check as this field would be highly unreliable, and rely on our rules instead
+	if f.InApp != nil && (p.Platform == f.Platform) {
 		return *f.InApp
 	}
-	switch p.Platform {
+	switch f.Platform {
 	case platform.Node:
 		return f.IsNodeApplicationFrame()
 	case platform.JavaScript:

--- a/internal/sample/sample_test.go
+++ b/internal/sample/sample_test.go
@@ -1008,7 +1008,7 @@ func TestNormalizeFramesPerPlatform(t *testing.T) {
 			},
 		},
 		{
-			name: "react-native with cocoa",
+			name: "react-native with cocoa hermes frame",
 			input: Profile{
 				RawProfile: RawProfile{
 					Platform: platform.JavaScript,
@@ -1037,6 +1037,47 @@ func TestNormalizeFramesPerPlatform(t *testing.T) {
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "hermes::vm::Interpreter::createObjectFromBuffer(hermes::vm::Runtime\u0026, hermes::vm::CodeBlock*, unsigned int, unsigned int, unsigned int)",
 								Package:  "/private/var/containers/Bundle/Application/0DA082D7-05F5-413F-892B-642FD331230C/BIGW.app/Frameworks/hermes.framework/hermes",
+								InApp:    &testutil.False,
+								Platform: "cocoa",
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "react-native with cocoa system library",
+			input: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.JavaScript,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
+								Function: "swift_conformsToProtocolMaybeInstantiateSuperclasses(swift::TargetMetadata\u003cswift::InProcess\u003e const*, swift::TargetProtocolDescriptor\u003cswift::InProcess\u003e const*, bool)::$_8::operator()((anonymous namespace)::ConformanceSection const\u0026) const::{lambda(swift::TargetProtocolConformanceDescriptor\u003cswift::InProcess\u003e const\u0026)#1}::operator()(swift::TargetProtocolConformanceDescriptor\u003cswift::InProcess\u003e const\u0026) const",
+								Package:  "/usr/lib/swift/libswiftCore.dylib",
+								InApp:    &testutil.True,
+								Platform: "cocoa",
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+					},
+				},
+			},
+			output: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.JavaScript,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
+								Function: "swift_conformsToProtocolMaybeInstantiateSuperclasses(swift::TargetMetadata\u003cswift::InProcess\u003e const*, swift::TargetProtocolDescriptor\u003cswift::InProcess\u003e const*, bool)::$_8::operator()((anonymous namespace)::ConformanceSection const\u0026) const::{lambda(swift::TargetProtocolConformanceDescriptor\u003cswift::InProcess\u003e const\u0026)#1}::operator()(swift::TargetProtocolConformanceDescriptor\u003cswift::InProcess\u003e const\u0026) const",
+								Package:  "/usr/lib/swift/libswiftCore.dylib",
 								InApp:    &testutil.False,
 								Platform: "cocoa",
 							},

--- a/internal/sample/sample_test.go
+++ b/internal/sample/sample_test.go
@@ -550,19 +550,23 @@ func TestTrimCocoaStacks(t *testing.T) {
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function1",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function2",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "main",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
-								Data: frame.Data{SymbolicatorStatus: "missing"},
+								Data:     frame.Data{SymbolicatorStatus: "missing"},
+								Platform: "cocoa",
 							},
 						},
 						Stacks: []Stack{
@@ -580,20 +584,24 @@ func TestTrimCocoaStacks(t *testing.T) {
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function1",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function2",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "main",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
-								Data:  frame.Data{SymbolicatorStatus: "missing"},
-								InApp: &testutil.False,
+								Data:     frame.Data{SymbolicatorStatus: "missing"},
+								InApp:    &testutil.False,
+								Platform: "cocoa",
 							},
 						},
 						Stacks: []Stack{
@@ -614,24 +622,29 @@ func TestTrimCocoaStacks(t *testing.T) {
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function1",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function2",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "main",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
-								Data: frame.Data{SymbolicatorStatus: "missing"},
+								Data:     frame.Data{SymbolicatorStatus: "missing"},
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "start_sim",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 						},
 						Stacks: []Stack{
@@ -649,25 +662,30 @@ func TestTrimCocoaStacks(t *testing.T) {
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function1",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function2",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "main",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
-								Data:  frame.Data{SymbolicatorStatus: "missing"},
-								InApp: &testutil.False,
+								Data:     frame.Data{SymbolicatorStatus: "missing"},
+								InApp:    &testutil.False,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "start_sim",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 						},
 						Stacks: []Stack{
@@ -688,24 +706,29 @@ func TestTrimCocoaStacks(t *testing.T) {
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function1",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function2",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "missing"},
 								Function: "unsymbolicated_main",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
-								Data: frame.Data{SymbolicatorStatus: "missing"},
+								Data:     frame.Data{SymbolicatorStatus: "missing"},
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "start_sim",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 						},
 						Stacks: []Stack{
@@ -723,25 +746,30 @@ func TestTrimCocoaStacks(t *testing.T) {
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function1",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function2",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "missing"},
 								Function: "unsymbolicated_main",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
-								Data:  frame.Data{SymbolicatorStatus: "missing"},
-								InApp: &testutil.False,
+								Data:     frame.Data{SymbolicatorStatus: "missing"},
+								InApp:    &testutil.False,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "start_sim",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 						},
 						Stacks: []Stack{
@@ -762,24 +790,29 @@ func TestTrimCocoaStacks(t *testing.T) {
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function1",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function2",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "main",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
-								Data: frame.Data{SymbolicatorStatus: "missing"},
+								Data:     frame.Data{SymbolicatorStatus: "missing"},
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "start_sim",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 						},
 						Stacks: []Stack{
@@ -801,25 +834,30 @@ func TestTrimCocoaStacks(t *testing.T) {
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function1",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "function2",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "main",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 							{
-								Data:  frame.Data{SymbolicatorStatus: "missing"},
-								InApp: &testutil.False,
+								Data:     frame.Data{SymbolicatorStatus: "missing"},
+								InApp:    &testutil.False,
+								Platform: "cocoa",
 							},
 							{
 								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
 								Function: "start_sim",
 								InApp:    &testutil.True,
+								Platform: "cocoa",
 							},
 						},
 						Stacks: []Stack{
@@ -939,6 +977,7 @@ func TestNormalizeFramesPerPlatform(t *testing.T) {
 								File:     "threading.py",
 								Module:   "threading",
 								Path:     "/usr/local/lib/python3.8/threading.py",
+								Platform: "python",
 							},
 						},
 						Stacks: []Stack{
@@ -958,6 +997,48 @@ func TestNormalizeFramesPerPlatform(t *testing.T) {
 								Module:   "threading",
 								Path:     "/usr/local/lib/python3.8/threading.py",
 								InApp:    &testutil.False,
+								Platform: "python",
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "react-native with cocoa",
+			input: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.JavaScript,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
+								Function: "hermes::vm::Interpreter::createObjectFromBuffer(hermes::vm::Runtime\u0026, hermes::vm::CodeBlock*, unsigned int, unsigned int, unsigned int)",
+								Package:  "/private/var/containers/Bundle/Application/0DA082D7-05F5-413F-892B-642FD331230C/BIGW.app/Frameworks/hermes.framework/hermes",
+								InApp:    &testutil.True,
+								Platform: "cocoa",
+							},
+						},
+						Stacks: []Stack{
+							{0},
+						},
+					},
+				},
+			},
+			output: Profile{
+				RawProfile: RawProfile{
+					Platform: platform.JavaScript,
+					Trace: Trace{
+						Frames: []frame.Frame{
+							{
+								Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
+								Function: "hermes::vm::Interpreter::createObjectFromBuffer(hermes::vm::Runtime\u0026, hermes::vm::CodeBlock*, unsigned int, unsigned int, unsigned int)",
+								Package:  "/private/var/containers/Bundle/Application/0DA082D7-05F5-413F-892B-642FD331230C/BIGW.app/Frameworks/hermes.framework/hermes",
+								InApp:    &testutil.False,
+								Platform: "cocoa",
 							},
 						},
 						Stacks: []Stack{
@@ -1101,6 +1182,7 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 								File:     "threading.py",
 								Module:   "threading",
 								Path:     "/usr/local/lib/python3.8/threading.py",
+								Platform: "python",
 							},
 						},
 						Stacks: []Stack{
@@ -1139,6 +1221,7 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 							Module:   "threading",
 							InApp:    &testutil.False,
 							Path:     "/usr/local/lib/python3.8/threading.py",
+							Platform: "python",
 						},
 					},
 				},


### PR DESCRIPTION
For react-native the `in_app field` seems to be messed up most of the times, with system libraries and other frames that are clearly system frames labelled as `in_app`.

This is likely because RN uses static libraries which are bundled into the app binary.
When symbolicated they are marked in_app.

For this platform we'll have to skip the `in_app` check altogether and instead rely on our custom defined checks that we normally do when `in_app==nil`