### PR TITLE
filter out system frames when ingesting functions into generic metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add support for writing function metrics to generic metrics platform ([#422](https://github.com/getsentry/vroom/pull/422))
 - Add support to ingest metric_summaries for profile functions ([#431](https://github.com/getsentry/vroom/pull/431))
 - Add platform field to android methods to align with the sample format ([#442](https://github.com/getsentry/vroom/pull/442))
+- Filter out system frames when ingesting functions into generic metrics ([#444](https://github.com/getsentry/vroom/pull/444))
 
 **Bug Fixes**:
 

--- a/cmd/vroom/profile.go
+++ b/cmd/vroom/profile.go
@@ -156,11 +156,14 @@ func (env *environment) postProfile(w http.ResponseWriter, r *http.Request) {
 		s = sentry.StartSpan(ctx, "processing")
 		s.Description = "Extract functions"
 		functions := extractFunctionsFromCallTrees(profilePlatform, callTrees)
+		// Cap but don't filter out system frames.
+		// Necessary until front end changes are in place.
+		functionsDataset := capAndFilterFunctions(functions, false)
 		s.Finish()
 
 		s = sentry.StartSpan(ctx, "json.marshal")
 		s.Description = "Marshal functions Kafka message"
-		b, err := json.Marshal(buildFunctionsKafkaMessage(p, functions))
+		b, err := json.Marshal(buildFunctionsKafkaMessage(p, functionsDataset))
 		s.Finish()
 		if err != nil {
 			hub.CaptureException(err)
@@ -183,7 +186,9 @@ func (env *environment) postProfile(w http.ResponseWriter, r *http.Request) {
 		if p.GetOptions().ProjectDSN != "" {
 			s = sentry.StartSpan(ctx, "processing")
 			s.Description = "Extract metrics from functions"
-			metrics, metricsSummary := extractMetricsFromFunctions(&p, functions)
+			// Cap and filter out system frames.
+			functionsMetricPlatform := capAndFilterFunctions(functions, true)
+			metrics, metricsSummary := extractMetricsFromFunctions(&p, functionsMetricPlatform)
 			s.Finish()
 
 			if len(metrics) > 0 {
@@ -267,11 +272,28 @@ func extractFunctionsFromCallTrees(
 	sort.SliceStable(functionsList, func(i, j int) bool {
 		return functionsList[i].SumSelfTimeNS > functionsList[j].SumSelfTimeNS
 	})
-	if len(functionsList) > maxUniqueFunctionsPerProfile {
-		functionsList = functionsList[:maxUniqueFunctionsPerProfile]
-	}
 
 	return functionsList
+}
+
+func capAndFilterFunctions(functions []nodetree.CallTreeFunction, filterSystemFrames bool) []nodetree.CallTreeFunction {
+	if !filterSystemFrames {
+		if len(functions) > maxUniqueFunctionsPerProfile {
+			return functions[:maxUniqueFunctionsPerProfile]
+		}
+		return functions
+	}
+	appFunctions := make([]nodetree.CallTreeFunction, 0, len(functions))
+	for _, f := range functions {
+		if !f.InApp {
+			continue
+		}
+		appFunctions = append(appFunctions, f)
+		if len(appFunctions) == maxUniqueFunctionsPerProfile {
+			break
+		}
+	}
+	return appFunctions
 }
 
 func (env *environment) getRawProfile(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This changes aim at dropping system frames when ingesting function metrics into the generic metrics platform.

Currently this would break the front-end in a few places. The logic to cap the list of functions to at most `maxUniqueFunctionsPerProfile` has therefore been moved out of the `extractFunctionsFromCallTrees` function and into a new one so that we can keep ingesting all of the frames for the current (custom) `functions` dataset, but we can start dropping them when ingesting into the generic metrics platform.

Once the front-end changes will be in place we can move this logic back to `extractFunctionsFromCallTrees` and simplify it even more.

To be merged after #441 