### PR TITLE
ref: skip metrics summary logic altogether if there are no metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Bump trufflesecurity/trufflehog from 3.71.1 to 3.71.2 ([#435](https://github.com/getsentry/vroom/pull/435))
 - Bump trufflesecurity/trufflehog from 3.71.2 to 3.72.0 ([#436](https://github.com/getsentry/vroom/pull/436))
 - Bump trufflesecurity/trufflehog from 3.72.0 to 3.73.0 ([#440](https://github.com/getsentry/vroom/pull/440))
+- Skip metrics summary logic altogether if there are no metrics ([#445](https://github.com/getsentry/vroom/pull/445))
 
 ## 23.12.0
 

--- a/cmd/vroom/profile.go
+++ b/cmd/vroom/profile.go
@@ -198,7 +198,7 @@ func (env *environment) postProfile(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Only send a profile sample to the metrics_summary if it's an indexed profile
-			if p.IsSampled() {
+			if p.IsSampled() && len(metrics) > 0 {
 				kafkaMessages, err := generateMetricSummariesKafkaMessageBatch(&p, metrics, metricsSummary)
 				if err != nil {
 					hub.CaptureException(err)


### PR DESCRIPTION
micro-optimization: if there are no metrics we can avoid making a call into `generateMetricSummariesKafkaMessageBatch` only to generate an empty slice that is then returned and passed to a kafka writer which in turn, has nothing to do either.