### PR TITLE
feat: Push public images in a new Artifact Registry repo

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,14 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'us.gcr.io/internal-sentry/vroom:$COMMIT_SHA', '.']
-images: ['us.gcr.io/internal-sentry/vroom:$COMMIT_SHA']
+  args: [
+    'build',
+    '-t', 'us.gcr.io/internal-sentry/vroom:$COMMIT_SHA',
+    '-t', 'us-central1-docker.pkg.dev/sentryio/vroom:$COMMIT_SHA',
+    '-t', 'us-central1-docker.pkg.dev/sentryio/vroom:latest',
+    '.',
+  ]
+images: [
+  'us.gcr.io/internal-sentry/vroom:$COMMIT_SHA',
+  'us-central1-docker.pkg.dev/sentryio/vroom:$COMMIT_SHA',
+  'us-central1-docker.pkg.dev/sentryio/vroom:latest',
+]


### PR DESCRIPTION
Container Registry is shutting down, we need to transition to Artifact Registry. This repository will be public and the central source to get `vroom` images for production and self-hosted.

#skip-changelog