### PR TITLE
fix: Fix Craft config to look at the right GitHub action for status

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -6,7 +6,7 @@ statusProvider:
   name: github
   config:
     contexts:
-      - 'vroom-build-docker-image-commit (sentryio)'
+      - 'build-vroom (sentryio)'
 targets:
   - name: github
   - id: release


### PR DESCRIPTION
#skip-changelog