### PR TITLE
fix: reuse one http client across different requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@
 - Android enter/exit checks should be per thread ([#429](https://github.com/getsentry/vroom/pull/429))
 - Store js/node frames symbolicator status ([#439](https://github.com/getsentry/vroom/pull/439))
 - Fix react native (with cocoa) profile normalization ([#443](https://github.com/getsentry/vroom/pull/443))
-
 - Set 5s timeout for http client used to send metrics ([#457](https://github.com/getsentry/vroom/pull/457))
+- Reuse one http client across different requests ([#458](https://github.com/getsentry/vroom/pull/458))
 
 **Internal**:
 

--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -40,6 +40,8 @@ type environment struct {
 	metricSummaryWriter *kafka.Writer
 
 	storage *blob.Bucket
+
+	metricsClient *http.Client
 }
 
 var release string
@@ -94,6 +96,15 @@ func newEnvironment() (*environment, error) {
 		ReadTimeout:  3 * time.Second,
 		Topic:        e.config.MetricsSummaryKafkaTopic,
 		WriteTimeout: 3 * time.Second,
+	}
+	e.metricsClient = &http.Client{
+		Timeout: time.Second * 5,
+		Transport: &http.Transport{
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 100,
+			MaxConnsPerHost:     100,
+			IdleConnTimeout:     time.Second * 60,
+		},
 	}
 	return &e, nil
 }

--- a/cmd/vroom/profile.go
+++ b/cmd/vroom/profile.go
@@ -193,7 +193,7 @@ func (env *environment) postProfile(w http.ResponseWriter, r *http.Request) {
 			if len(metrics) > 0 {
 				s = sentry.StartSpan(ctx, "processing")
 				s.Description = "Send functions metrics to generic metrics platform"
-				sendMetrics(&p, metrics)
+				sendMetrics(&p, metrics, env.metricsClient)
 				s.Finish()
 			}
 

--- a/cmd/vroom/utils.go
+++ b/cmd/vroom/utils.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"math"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -204,7 +205,7 @@ func extractMetricsFromFunctions(p *profile.Profile, functions []nodetree.CallTr
 	return metrics, metricsSummary
 }
 
-func sendMetrics(p *profile.Profile, metrics []sentry.Metric) {
+func sendMetrics(p *profile.Profile, metrics []sentry.Metric, mClient *http.Client) {
 	id := strings.Replace(uuid.New().String(), "-", "", -1)
 	e := sentry.NewEvent()
 	e.EventID = sentry.EventID(id)
@@ -213,7 +214,9 @@ func sendMetrics(p *profile.Profile, metrics []sentry.Metric) {
 	tr := sentry.NewHTTPSyncTransport()
 	tr.Timeout = 5 * time.Second
 	tr.Configure(sentry.ClientOptions{
-		Dsn: p.GetOptions().ProjectDSN,
+		Dsn:           p.GetOptions().ProjectDSN,
+		HTTPTransport: mClient.Transport,
+		HTTPClient:    mClient,
 	})
 
 	tr.SendEvent(e)


### PR DESCRIPTION
We should always reuse an http client across different requests as they're thread-safe and meant to be reused for better performance (connection pooling).

This will avoid creating a new one (and relative http transport) for each and every requests we make to send metrics.

Not doing this might lead to temporary port exhaustion and degradation of perfomances.