### PR TITLE
fix correct in_app classification for [Native] js frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix react native (with cocoa) profile normalization ([#443](https://github.com/getsentry/vroom/pull/443))
 - Set 5s timeout for http client used to send metrics ([#457](https://github.com/getsentry/vroom/pull/457))
 - Reuse one http client across different requests ([#458](https://github.com/getsentry/vroom/pull/458))
+- Fix correct in_app classification for `[Native]` js frames ([#464](https://github.com/getsentry/vroom/pull/464))
 
 **Internal**:
 

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -161,6 +161,10 @@ func (f Frame) IsNodeApplicationFrame() bool {
 }
 
 func (f Frame) IsJavaScriptApplicationFrame() bool {
+	if strings.HasPrefix(f.Function, "[Native]") {
+		return false
+	}
+
 	if len(f.Path) == 0 {
 		return true
 	}

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -161,7 +161,7 @@ func (f Frame) IsNodeApplicationFrame() bool {
 }
 
 func (f Frame) IsJavaScriptApplicationFrame() bool {
-	if strings.HasPrefix(f.Function, "[Native]") || strings.HasPrefix(f.Function, "[HostFunction]") || strings.HasPrefix(f.Function, "[GC") {
+	if strings.HasPrefix(f.Function, "[") {
 		return false
 	}
 

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -161,7 +161,7 @@ func (f Frame) IsNodeApplicationFrame() bool {
 }
 
 func (f Frame) IsJavaScriptApplicationFrame() bool {
-	if strings.HasPrefix(f.Function, "[Native]") {
+	if strings.HasPrefix(f.Function, "[Native]") || strings.HasPrefix(f.Function, "[HostFunction]") || strings.HasPrefix(f.Function, "[GC") {
 		return false
 	}
 

--- a/internal/frame/frame_test.go
+++ b/internal/frame/frame_test.go
@@ -242,6 +242,13 @@ func TestIsJavaScriptApplicationFrame(t *testing.T) {
 			},
 			isApplication: false,
 		},
+		{
+			name: "native",
+			frame: Frame{
+				Function: "[Native] functionPrototypeApply",
+			},
+			isApplication: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/frame/frame_test.go
+++ b/internal/frame/frame_test.go
@@ -249,6 +249,20 @@ func TestIsJavaScriptApplicationFrame(t *testing.T) {
 			},
 			isApplication: false,
 		},
+		{
+			name: "host_function",
+			frame: Frame{
+				Function: "[HostFunction] nativeCallSyncHook",
+			},
+			isApplication: false,
+		},
+		{
+			name: "gc",
+			frame: Frame{
+				Function: "[GC Young Gen]",
+			},
+			isApplication: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
with this we'll classify js frame whose function starts with `[Native]` as system frames.