### PR TITLE
ref: remove unused flamegraph endpoint (dead code)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - Set logger for sentry client and replace zerolog with slog ([#461](https://github.com/getsentry/vroom/pull/461))
 - Rename logger msg key to message ([#462](https://github.com/getsentry/vroom/pull/462))
 - Bump github.com/Azure/azure-sdk-for-go/sdk/azidentity from 1.2.1 to 1.6.0 ([#471](https://github.com/getsentry/vroom/pull/471))
+- Remove unused flamegraph endpoint (dead code) ([#472](https://github.com/getsentry/vroom/pull/472))
 
 ## 23.12.0
 

--- a/cmd/vroom/flamegraph.go
+++ b/cmd/vroom/flamegraph.go
@@ -11,83 +11,12 @@ import (
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/getsentry/vroom/internal/flamegraph"
-	"github.com/getsentry/vroom/internal/snubautil"
 )
 
 const (
 	minNumWorkers int           = 5
 	timeout       time.Duration = time.Second * 5
 )
-
-func (env *environment) getFlamegraph(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	hub := sentry.GetHubFromContext(ctx)
-	ps := httprouter.ParamsFromContext(ctx)
-	rawOrganizationID := ps.ByName("organization_id")
-	organizationID, err := strconv.ParseUint(rawOrganizationID, 10, 64)
-	if err != nil {
-		hub.CaptureException(err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	hub.Scope().SetTag("organization_id", rawOrganizationID)
-
-	rawProjectID := ps.ByName("project_id")
-	projectID, err := strconv.ParseUint(rawProjectID, 10, 64)
-	if err != nil {
-		sentry.CaptureException(err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	urlValues := r.URL.Query()
-	urlValues.Set("project_id", rawProjectID)
-	r.URL.RawQuery = urlValues.Encode()
-
-	hub.Scope().SetTag("project_id", rawProjectID)
-
-	sqb, err := env.profilesQueryBuilderFromRequest(ctx, r.URL.Query(), organizationID)
-	if err != nil {
-		hub.CaptureException(err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	s := sentry.StartSpan(ctx, "snuba.read")
-	profileIDs, err := snubautil.GetProfileIDs(organizationID, 100, sqb)
-	if err != nil {
-		s.Finish()
-		hub.CaptureException(err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	hub.Scope().SetTag("fetched_profiles", strconv.Itoa(len(profileIDs)))
-	s.Finish()
-
-	s = sentry.StartSpan(ctx, "processing")
-	speedscope, err := flamegraph.GetFlamegraphFromProfiles(ctx, env.storage, organizationID, projectID, profileIDs, nil, minNumWorkers, timeout)
-	if err != nil {
-		s.Finish()
-		hub.CaptureException(err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	s.Finish()
-
-	s = sentry.StartSpan(ctx, "json.marshal")
-	defer s.Finish()
-	b, err := json.Marshal(speedscope)
-	if err != nil {
-		hub.CaptureException(err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(b)
-}
 
 type postFlamegraphFromProfileIDs struct {
 	ProfileIDs []string `json:"profile_ids"`

--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -163,11 +163,6 @@ func (e *environment) newRouter() (*httprouter.Router, error) {
 			e.getProfileIDByTransactionID,
 		},
 		{
-			http.MethodGet,
-			"/organizations/:organization_id/projects/:project_id/flamegraph",
-			e.getFlamegraph,
-		},
-		{
 			http.MethodPost,
 			"/organizations/:organization_id/projects/:project_id/flamegraph",
 			e.postFlamegraphFromProfileIDs,


### PR DESCRIPTION
This was an older implementation where the profile IDs where fetched directly in vroom.
This was dismissed in favour of the next version that fetched the profile IDs in sentry and posted them to vroom, whose only task it to download and aggregate the data.


Related to https://github.com/getsentry/sentry/pull/72581