### PR TITLE
pass the unmarshaled chunk instead of the body request to CompressedWrite

### DIFF
--- a/cmd/vroom/chunk.go
+++ b/cmd/vroom/chunk.go
@@ -60,7 +60,7 @@ func (env *environment) postChunk(w http.ResponseWriter, r *http.Request) {
 
 	s = sentry.StartSpan(ctx, "gcs.write")
 	s.Description = "Write profile to GCS"
-	err = storageutil.CompressedWrite(ctx, env.storage, c.StoragePath(), body)
+	err = storageutil.CompressedWrite(ctx, env.storage, c.StoragePath(), c)
 	s.Finish()
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {


### PR DESCRIPTION
#skip-changelog