### PR TITLE
feat(chunks): Filter out samples before start and after end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - Remove unused flamegraph endpoint (dead code) ([#472](https://github.com/getsentry/vroom/pull/472))
 - Remove unused functions endpoint (dead code) ([#474](https://github.com/getsentry/vroom/pull/474))
 - Serialize chunk fields with lower case ([#483](https://github.com/getsentry/vroom/pull/483))
+- Filter out samples before start and after end ([#484](https://github.com/getsentry/vroom/pull/484))
 
 ## 23.12.0
 

--- a/cmd/vroom/chunk.go
+++ b/cmd/vroom/chunk.go
@@ -117,6 +117,8 @@ func (env *environment) postChunk(w http.ResponseWriter, r *http.Request) {
 type postProfileFromChunkIDsRequest struct {
 	ProfilerID string   `json:"profiler_id"`
 	ChunkIDs   []string `json:"chunk_ids"`
+	Start      uint64   `json:"start,string"`
+	End        uint64   `json:"end,string"`
 }
 
 // Instead of returning Chunk directly, we'll return this struct
@@ -127,7 +129,7 @@ type postProfileFromChunkIDsResponse struct {
 	Chunk chunk.Chunk `json:"chunk"`
 }
 
-// This is more of a GET method, but since we're receeiving a list of chunk IDs as part of a
+// This is more of a GET method, but since we're receiving a list of chunk IDs as part of a
 // body request, we use a POST method instead (similarly to the flamegraph endpoint).
 func (env *environment) postProfileFromChunkIDs(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -222,7 +224,7 @@ func (env *environment) postProfileFromChunkIDs(w http.ResponseWriter, r *http.R
 
 	s = sentry.StartSpan(ctx, "chunks.merge")
 	s.Description = "Merge profile chunks into a single one"
-	chunk, err := chunk.MergeChunks(chunks)
+	chunk, err := chunk.MergeChunks(chunks, float64(requestBody.Start), float64(requestBody.End))
 	s.Finish()
 	if err != nil {
 		hub.CaptureException(err)

--- a/cmd/vroom/chunk.go
+++ b/cmd/vroom/chunk.go
@@ -224,7 +224,7 @@ func (env *environment) postProfileFromChunkIDs(w http.ResponseWriter, r *http.R
 
 	s = sentry.StartSpan(ctx, "chunks.merge")
 	s.Description = "Merge profile chunks into a single one"
-	chunk, err := chunk.MergeChunks(chunks, float64(requestBody.Start), float64(requestBody.End))
+	chunk, err := chunk.MergeChunks(chunks, requestBody.Start, requestBody.End)
 	s.Finish()
 	if err != nil {
 		hub.CaptureException(err)

--- a/internal/chunk/chunk_utils_test.go
+++ b/internal/chunk/chunk_utils_test.go
@@ -14,8 +14,8 @@ func TestMergeChunks(t *testing.T) {
 		name  string
 		have  []Chunk
 		want  Chunk
-		start float64
-		end   float64
+		start uint64
+		end   uint64
 	}{
 		{
 			name: "contiguous chunks",
@@ -84,8 +84,8 @@ func TestMergeChunks(t *testing.T) {
 				},
 				Measurements: json.RawMessage(`{"first_metric":{"unit":"ms","values":[{"timestamp":1,"value":1},{"timestamp":2,"value":1.2}]}}`),
 			},
-			start: 1e9,
-			end:   4e9,
+			start: uint64(1e9),
+			end:   uint64(4e9),
 		},
 	}
 

--- a/internal/chunk/chunk_utils_test.go
+++ b/internal/chunk/chunk_utils_test.go
@@ -11,9 +11,11 @@ import (
 
 func TestMergeChunks(t *testing.T) {
 	tests := []struct {
-		name string
-		have []Chunk
-		want Chunk
+		name  string
+		have  []Chunk
+		want  Chunk
+		start float64
+		end   float64
 	}{
 		{
 			name: "contiguous chunks",
@@ -25,8 +27,9 @@ func TestMergeChunks(t *testing.T) {
 							{Function: "d"},
 						},
 						Samples: []Sample{
-							{StackID: 0, Timestamp: 2.0},
-							{StackID: 1, Timestamp: 3.0},
+							{StackID: 0, Timestamp: 3.0},
+							{StackID: 1, Timestamp: 4.0},
+							{StackID: 1, Timestamp: 5.0}, // outside range, will be dropped
 						},
 						Stacks: [][]int{
 							{0, 1},
@@ -45,7 +48,8 @@ func TestMergeChunks(t *testing.T) {
 						},
 						Samples: []Sample{
 							{StackID: 0, Timestamp: 0.0},
-							{StackID: 1, Timestamp: 1.0},
+							{StackID: 0, Timestamp: 1.0},
+							{StackID: 1, Timestamp: 2.0},
 						},
 						Stacks: [][]int{
 							{0, 1},
@@ -65,10 +69,10 @@ func TestMergeChunks(t *testing.T) {
 						{Function: "d"},
 					},
 					Samples: []Sample{
-						{StackID: 0, Timestamp: 0.0},
-						{StackID: 1, Timestamp: 1.0},
-						{StackID: 2, Timestamp: 2.0},
-						{StackID: 3, Timestamp: 3.0},
+						{StackID: 0, Timestamp: 1.0},
+						{StackID: 1, Timestamp: 2.0},
+						{StackID: 2, Timestamp: 3.0},
+						{StackID: 3, Timestamp: 4.0},
 					},
 					Stacks: [][]int{
 						{0, 1},
@@ -80,12 +84,14 @@ func TestMergeChunks(t *testing.T) {
 				},
 				Measurements: json.RawMessage(`{"first_metric":{"unit":"ms","values":[{"timestamp":1,"value":1},{"timestamp":2,"value":1.2}]}}`),
 			},
+			start: 1e9,
+			end:   4e9,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			have, err := MergeChunks(test.have)
+			have, err := MergeChunks(test.have, test.start, test.end)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This was returning the entire chunk all the time but we want to slice it to be between the specified start/end times.