### PR TITLE
ref(chunks): Generalize chunk task input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 - Serialize chunk fields with lower case ([#483](https://github.com/getsentry/vroom/pull/483))
 - Filter out samples before start and after end ([#484](https://github.com/getsentry/vroom/pull/484))
 - Remove unused endpoint for profiling filters ([#485](https://github.com/getsentry/vroom/pull/485))
-- Generalize chunk task input ([#485](https://github.com/getsentry/vroom/pull/486))
+- Generalize chunk task input ([#486](https://github.com/getsentry/vroom/pull/486))
 
 ## 23.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - Serialize chunk fields with lower case ([#483](https://github.com/getsentry/vroom/pull/483))
 - Filter out samples before start and after end ([#484](https://github.com/getsentry/vroom/pull/484))
 - Remove unused endpoint for profiling filters ([#485](https://github.com/getsentry/vroom/pull/485))
+- Generalize chunk task input ([#485](https://github.com/getsentry/vroom/pull/486))
 
 ## 23.12.0
 

--- a/cmd/vroom/chunk.go
+++ b/cmd/vroom/chunk.go
@@ -173,7 +173,7 @@ func (env *environment) postProfileFromChunkIDs(w http.ResponseWriter, r *http.R
 	defer close(results)
 	// send a task to the workers pool for each chunk
 	for _, ID := range requestBody.ChunkIDs {
-		readJobs <- &chunk.ReadJob{
+		readJobs <- chunk.ReadJob{
 			Ctx:            ctx,
 			Storage:        env.storage,
 			OrganizationID: organizationID,

--- a/cmd/vroom/flamegraph.go
+++ b/cmd/vroom/flamegraph.go
@@ -140,7 +140,7 @@ func (env *environment) postFlamegraphFromChunksMetadata(w http.ResponseWriter, 
 	}
 
 	s = sentry.StartSpan(ctx, "processing")
-	speedscope, err := flamegraph.GetFlamegraphFromChunks(ctx, organizationID, projectID, env.storage, body.ChunksMetadata, jobs)
+	speedscope, err := flamegraph.GetFlamegraphFromChunks(ctx, organizationID, projectID, env.storage, body.ChunksMetadata, readJobs)
 	s.Finish()
 	if err != nil {
 		if hub != nil {

--- a/internal/chunk/readjob.go
+++ b/internal/chunk/readjob.go
@@ -24,7 +24,7 @@ type (
 	}
 )
 
-func (job *ReadJob) Read() {
+func (job ReadJob) Read() {
 	var chunk Chunk
 
 	err := storageutil.UnmarshalCompressed(

--- a/internal/chunk/readjob.go
+++ b/internal/chunk/readjob.go
@@ -1,0 +1,38 @@
+package chunk
+
+import (
+	"context"
+
+	"github.com/getsentry/vroom/internal/storageutil"
+	"gocloud.dev/blob"
+)
+
+type (
+	ReadJob struct {
+		Ctx            context.Context
+		Storage        *blob.Bucket
+		OrganizationID uint64
+		ProjectID      uint64
+		ProfilerID     string
+		ChunkID        string
+		Result         chan<- ReadJobResult
+	}
+
+	ReadJobResult struct {
+		Err   error
+		Chunk Chunk
+	}
+)
+
+func (job *ReadJob) Read() {
+	var chunk Chunk
+
+	err := storageutil.UnmarshalCompressed(
+		job.Ctx,
+		job.Storage,
+		StoragePath(job.OrganizationID, job.ProjectID, job.ProfilerID, job.ChunkID),
+		&chunk,
+	)
+
+	job.Result <- ReadJobResult{Chunk: chunk, Err: err}
+}

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -336,15 +336,15 @@ func GetFlamegraphFromChunks(
 	projectID uint64,
 	storage *blob.Bucket,
 	chunksMetadata []ChunkMetadata,
-	jobs chan chunk.TaskInput) (speedscope.Output, error) {
+	jobs chan storageutil.ReadJob) (speedscope.Output, error) {
 	hub := sentry.GetHubFromContext(ctx)
-	results := make(chan chunk.TaskOutput, len(chunksMetadata))
+	results := make(chan chunk.ReadJobResult, len(chunksMetadata))
 	defer close(results)
 
 	chunkIDToMetadata := make(map[string]ChunkMetadata)
 	for _, chunkMetadata := range chunksMetadata {
 		chunkIDToMetadata[chunkMetadata.ChunkID] = chunkMetadata
-		jobs <- chunk.TaskInput{
+		jobs <- &chunk.ReadJob{
 			Ctx:            ctx,
 			ProfilerID:     chunkMetadata.ProfilerID,
 			ChunkID:        chunkMetadata.ChunkID,

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -344,7 +344,7 @@ func GetFlamegraphFromChunks(
 	chunkIDToMetadata := make(map[string]ChunkMetadata)
 	for _, chunkMetadata := range chunksMetadata {
 		chunkIDToMetadata[chunkMetadata.ChunkID] = chunkMetadata
-		jobs <- &chunk.ReadJob{
+		jobs <- chunk.ReadJob{
 			Ctx:            ctx,
 			ProfilerID:     chunkMetadata.ProfilerID,
 			ChunkID:        chunkMetadata.ChunkID,

--- a/internal/storageutil/storageutil.go
+++ b/internal/storageutil/storageutil.go
@@ -80,3 +80,13 @@ func UnmarshalCompressed(
 	}
 	return nil
 }
+
+type ReadJob interface {
+	Read()
+}
+
+func ReadWorker(jobs <-chan ReadJob) {
+	for job := range jobs {
+		job.Read()
+	}
+}


### PR DESCRIPTION
The chunk task input is too specific meaning we cannot reuse the worker pool. Generalize it in preparation for using it for profiles and profile chunks.