### PR TITLE
feat(flamegraph): Dual mode flamegraph endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add endpoint to return a profile from a list of chunk IDs ([#470](https://github.com/getsentry/vroom/pull/470))
 - Add callTree generation for profile chunks ([#475](https://github.com/getsentry/vroom/pull/475))
 - Support generating a flamegraph from a list of chunk IDs ([#476](https://github.com/getsentry/vroom/pull/476))
+- Dual mode flamegraph endpoint ([#487](https://github.com/getsentry/vroom/pull/487))
 
 **Bug Fixes**:
 
@@ -85,7 +86,6 @@
 - Filter out samples before start and after end ([#484](https://github.com/getsentry/vroom/pull/484))
 - Remove unused endpoint for profiling filters ([#485](https://github.com/getsentry/vroom/pull/485))
 - Generalize chunk task input ([#486](https://github.com/getsentry/vroom/pull/486))
-- Dual mode flamegraph endpoint ([#487](https://github.com/getsentry/vroom/pull/487))
 
 ## 23.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - Filter out samples before start and after end ([#484](https://github.com/getsentry/vroom/pull/484))
 - Remove unused endpoint for profiling filters ([#485](https://github.com/getsentry/vroom/pull/485))
 - Generalize chunk task input ([#486](https://github.com/getsentry/vroom/pull/486))
+- Dual mode flamegraph endpoint ([#487](https://github.com/getsentry/vroom/pull/487))
 
 ## 23.12.0
 

--- a/cmd/vroom/flamegraph.go
+++ b/cmd/vroom/flamegraph.go
@@ -169,3 +169,73 @@ func (env *environment) postFlamegraphFromChunksMetadata(w http.ResponseWriter, 
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(b)
 }
+
+type (
+	postFlamegraphBody struct {
+		Transaction []flamegraph.TransactionProfileCandidate `json:"transaction"`
+		Continuous  []flamegraph.ContinuousProfileCandidate  `json:"continuous"`
+	}
+)
+
+func (env *environment) postFlamegraph(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	hub := sentry.GetHubFromContext(ctx)
+	ps := httprouter.ParamsFromContext(ctx)
+	rawOrganizationID := ps.ByName("organization_id")
+	organizationID, err := strconv.ParseUint(rawOrganizationID, 10, 64)
+	if err != nil {
+		if hub != nil {
+			hub.CaptureException(err)
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	hub.Scope().SetTag("organization_id", rawOrganizationID)
+
+	var body postFlamegraphBody
+	s := sentry.StartSpan(ctx, "processing")
+	s.Description = "Decoding data"
+	err = json.NewDecoder(r.Body).Decode(&body)
+	s.Finish()
+	if err != nil {
+		if hub != nil {
+			hub.CaptureException(err)
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	s = sentry.StartSpan(ctx, "processing")
+	speedscope, err := flamegraph.GetFlamegraphFromCandidates(
+		ctx,
+		env.storage,
+		organizationID,
+		body.Transaction,
+		body.Continuous,
+		readJobs,
+	)
+	s.Finish()
+	if err != nil {
+		if hub != nil {
+			hub.CaptureException(err)
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	s = sentry.StartSpan(ctx, "json.marshal")
+	defer s.Finish()
+	b, err := json.Marshal(speedscope)
+	if err != nil {
+		if hub != nil {
+			hub.CaptureException(err)
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(b)
+}

--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -173,6 +173,11 @@ func (e *environment) newRouter() (*httprouter.Router, error) {
 			"/organizations/:organization_id/projects/:project_id/chunks",
 			e.postProfileFromChunkIDs,
 		},
+		{
+			http.MethodPost,
+			"/organizations/:organization_id/flamegraph",
+			e.postFlamegraph,
+		},
 		{http.MethodGet, "/health", e.getHealth},
 		{http.MethodPost, "/chunk", e.postChunk},
 		{http.MethodPost, "/profile", e.postProfile},

--- a/internal/chunk/readjob.go
+++ b/internal/chunk/readjob.go
@@ -15,16 +15,16 @@ type (
 		ProjectID      uint64
 		ProfilerID     string
 		ChunkID        string
-		Start          *uint64
-		End            *uint64
+		Start          uint64
+		End            uint64
 		Result         chan<- storageutil.ReadJobResult
 	}
 
 	ReadJobResult struct {
 		Err   error
 		Chunk Chunk
-		Start *uint64
-		End   *uint64
+		Start uint64
+		End   uint64
 	}
 )
 

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -445,8 +445,8 @@ func GetFlamegraphFromCandidates(
 			ProjectID:      candidate.ProjectID,
 			ProfilerID:     candidate.ProfilerID,
 			ChunkID:        candidate.ChunkID,
-			Start:          &candidate.Start,
-			End:            &candidate.End,
+			Start:          candidate.Start,
+			End:            candidate.End,
 			Storage:        storage,
 			Result:         results,
 		}
@@ -490,10 +490,10 @@ func GetFlamegraphFromCandidates(
 			}
 
 			for _, callTree := range chunkCallTrees {
-				if result.Start != nil && result.End != nil {
+				if result.Start > 0 && result.End > 0 {
 					interval := SpanInterval{
-						Start: *result.Start,
-						End:   *result.End,
+						Start: result.Start,
+						End:   result.End,
 					}
 					callTree = sliceCallTree(&callTree, &[]SpanInterval{interval})
 				}

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -32,6 +32,19 @@ type (
 		ChunkID       string         `json:"chunk_id"`
 		SpanIntervals []SpanInterval `json:"span_intervals,omitempty"`
 	}
+
+	TransactionProfileCandidate struct {
+		ProjectID uint64 `json:"project_id"`
+		ProfileID string `json:"profile_id"`
+	}
+
+	ContinuousProfileCandidate struct {
+		ProjectID  uint64 `json:"project_id"`
+		ProfilerID string `json:"profiler_id"`
+		ChunkID    string `json:"chunk_id"`
+		Start      uint64 `json:"start,string"`
+		End        uint64 `json:"end,string"`
+	}
 )
 
 var (
@@ -338,7 +351,7 @@ func GetFlamegraphFromChunks(
 	chunksMetadata []ChunkMetadata,
 	jobs chan storageutil.ReadJob) (speedscope.Output, error) {
 	hub := sentry.GetHubFromContext(ctx)
-	results := make(chan chunk.ReadJobResult, len(chunksMetadata))
+	results := make(chan storageutil.ReadJobResult, len(chunksMetadata))
 	defer close(results)
 
 	chunkIDToMetadata := make(map[string]ChunkMetadata)
@@ -360,21 +373,25 @@ func GetFlamegraphFromChunks(
 	// read the output of each tasks
 	for i := 0; i < len(chunksMetadata); i++ {
 		res := <-results
-		if res.Err != nil {
-			if errors.Is(res.Err, storageutil.ErrObjectNotFound) {
+		result, ok := res.(chunk.ReadJobResult)
+		if !ok {
+			continue
+		}
+		if result.Err != nil {
+			if errors.Is(result.Err, storageutil.ErrObjectNotFound) {
 				continue
 			}
-			if errors.Is(res.Err, context.DeadlineExceeded) {
-				return speedscope.Output{}, res.Err
+			if errors.Is(result.Err, context.DeadlineExceeded) {
+				return speedscope.Output{}, result.Err
 			}
 			if hub != nil {
-				hub.CaptureException(res.Err)
+				hub.CaptureException(result.Err)
 			}
 			continue
 		}
-		cm := chunkIDToMetadata[res.Chunk.ID]
+		cm := chunkIDToMetadata[result.Chunk.ID]
 		for _, interval := range cm.SpanIntervals {
-			callTrees, err := res.Chunk.CallTrees(&interval.ActiveThreadID)
+			callTrees, err := result.Chunk.CallTrees(&interval.ActiveThreadID)
 			if err != nil {
 				if hub != nil {
 					hub.CaptureException(err)
@@ -384,7 +401,7 @@ func GetFlamegraphFromChunks(
 			intervals := []SpanInterval{interval}
 			for _, callTree := range callTrees {
 				slicedTree := sliceCallTree(&callTree, &intervals)
-				addCallTreeToFlamegraph(&flamegraphTree, slicedTree, res.Chunk.ID)
+				addCallTreeToFlamegraph(&flamegraphTree, slicedTree, result.Chunk.ID)
 			}
 		}
 		countChunksAggregated++
@@ -395,4 +412,99 @@ func GetFlamegraphFromChunks(
 		hub.Scope().SetTag("processed_chunks", strconv.Itoa(countChunksAggregated))
 	}
 	return sp, nil
+}
+
+func GetFlamegraphFromCandidates(
+	ctx context.Context,
+	storage *blob.Bucket,
+	organizationID uint64,
+	transactionProfileCandidates []TransactionProfileCandidate,
+	continuousProfileCandidates []ContinuousProfileCandidate,
+	jobs chan storageutil.ReadJob,
+) (speedscope.Output, error) {
+	hub := sentry.GetHubFromContext(ctx)
+
+	results := make(chan storageutil.ReadJobResult, len(transactionProfileCandidates)+len(transactionProfileCandidates))
+	defer close(results)
+
+	for _, candidate := range transactionProfileCandidates {
+		jobs <- profile.ReadJob{
+			Ctx:            ctx,
+			OrganizationID: organizationID,
+			ProjectID:      candidate.ProjectID,
+			ProfileID:      candidate.ProfileID,
+			Storage:        storage,
+			Result:         results,
+		}
+	}
+
+	for _, candidate := range continuousProfileCandidates {
+		jobs <- chunk.ReadJob{
+			Ctx:            ctx,
+			OrganizationID: organizationID,
+			ProjectID:      candidate.ProjectID,
+			ProfilerID:     candidate.ProfilerID,
+			ChunkID:        candidate.ChunkID,
+			Start:          &candidate.Start,
+			End:            &candidate.End,
+			Storage:        storage,
+			Result:         results,
+		}
+	}
+
+	var flamegraphTree []*nodetree.Node
+
+	for res := range results {
+		err := res.Error()
+		if err != nil {
+			if errors.Is(err, storageutil.ErrObjectNotFound) {
+				continue
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				return speedscope.Output{}, err
+			}
+			if hub != nil {
+				hub.CaptureException(err)
+			}
+			continue
+		}
+
+		if result, ok := res.(profile.ReadJobResult); ok {
+			profileCallTrees, err := result.Profile.CallTrees()
+			if err != nil {
+				hub.CaptureException(err)
+				continue
+			}
+
+			for _, callTree := range profileCallTrees {
+				// TODO: properly pass the profile ID around
+				addCallTreeToFlamegraph(&flamegraphTree, callTree, "")
+			}
+		} else if result, ok := res.(chunk.ReadJobResult); ok {
+			// TODO: this takes all threads, make sure to pass a thread id
+			// at some point to only get call trees for that thread
+			chunkCallTrees, err := result.Chunk.CallTrees(nil)
+			if err != nil {
+				hub.CaptureException(err)
+				continue
+			}
+
+			for _, callTree := range chunkCallTrees {
+				if result.Start != nil && result.End != nil {
+					interval := SpanInterval{
+						Start: *result.Start,
+						End:   *result.End,
+					}
+					callTree = sliceCallTree(&callTree, &[]SpanInterval{interval})
+				}
+				// TODO: properly pass the profile ID around
+				addCallTreeToFlamegraph(&flamegraphTree, callTree, "")
+			}
+		} else {
+			// this should never happen
+			return speedscope.Output{}, errors.New("Unexpected result from storage")
+		}
+	}
+
+	return toSpeedscope(flamegraphTree, 4, 0), nil
 }

--- a/internal/profile/readjob.go
+++ b/internal/profile/readjob.go
@@ -1,4 +1,4 @@
-package chunk
+package profile
 
 import (
 	"context"
@@ -13,37 +13,27 @@ type (
 		Storage        *blob.Bucket
 		OrganizationID uint64
 		ProjectID      uint64
-		ProfilerID     string
-		ChunkID        string
-		Start          *uint64
-		End            *uint64
+		ProfileID      string
 		Result         chan<- storageutil.ReadJobResult
 	}
 
 	ReadJobResult struct {
-		Err   error
-		Chunk Chunk
-		Start *uint64
-		End   *uint64
+		Err     error
+		Profile Profile
 	}
 )
 
 func (job ReadJob) Read() {
-	var chunk Chunk
+	var profile Profile
 
 	err := storageutil.UnmarshalCompressed(
 		job.Ctx,
 		job.Storage,
-		StoragePath(job.OrganizationID, job.ProjectID, job.ProfilerID, job.ChunkID),
-		&chunk,
+		StoragePath(job.OrganizationID, job.ProjectID, job.ProfileID),
+		&profile,
 	)
 
-	job.Result <- ReadJobResult{
-		Err:   err,
-		Chunk: chunk,
-		Start: job.Start,
-		End:   job.End,
-	}
+	job.Result <- ReadJobResult{Profile: profile, Err: err}
 }
 
 func (result ReadJobResult) Error() error {

--- a/internal/storageutil/storageutil.go
+++ b/internal/storageutil/storageutil.go
@@ -81,9 +81,15 @@ func UnmarshalCompressed(
 	return nil
 }
 
-type ReadJob interface {
-	Read()
-}
+type (
+	ReadJob interface {
+		Read()
+	}
+
+	ReadJobResult interface {
+		Error() error
+	}
+)
 
 func ReadWorker(jobs <-chan ReadJob) {
 	for job := range jobs {


### PR DESCRIPTION
This introduces a new endpoint that generates a flamegraph compatible with both
transaction profiles and continuous profiles.