### PR TITLE
fix(flamegraphs): Do not iterate unclosed channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Reuse one http client across different requests ([#458](https://github.com/getsentry/vroom/pull/458))
 - Fix correct in_app classification for `[Native]` js frames ([#464](https://github.com/getsentry/vroom/pull/464))
 - Ignore react-native js frame for metrics aggregation when not symbolicated ([#465](https://github.com/getsentry/vroom/pull/465))
+- Do not iterate unclosed channel ([#489](https://github.com/getsentry/vroom/pull/489))
 
 **Internal**:
 


### PR DESCRIPTION
The channel only gets closed at the end of the function so iterating it will never terminate and just wait for the request to timeout. Since we know exactly how many values will be in the channel, iterate exactly that many times.