### PR TITLE
feat(profiling): Pass thread id to calltree generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add callTree generation for profile chunks ([#475](https://github.com/getsentry/vroom/pull/475))
 - Support generating a flamegraph from a list of chunk IDs ([#476](https://github.com/getsentry/vroom/pull/476))
 - Dual mode flamegraph endpoint ([#487](https://github.com/getsentry/vroom/pull/487))
+- Pass thread id to calltree generation ([#492](https://github.com/getsentry/vroom/pull/492))
 
 **Bug Fixes**:
 

--- a/internal/chunk/readjob.go
+++ b/internal/chunk/readjob.go
@@ -15,16 +15,18 @@ type (
 		ProjectID      uint64
 		ProfilerID     string
 		ChunkID        string
+		ThreadID       *string
 		Start          uint64
 		End            uint64
 		Result         chan<- storageutil.ReadJobResult
 	}
 
 	ReadJobResult struct {
-		Err   error
-		Chunk Chunk
-		Start uint64
-		End   uint64
+		Err      error
+		Chunk    Chunk
+		ThreadID *string
+		Start    uint64
+		End      uint64
 	}
 )
 
@@ -39,10 +41,11 @@ func (job ReadJob) Read() {
 	)
 
 	job.Result <- ReadJobResult{
-		Err:   err,
-		Chunk: chunk,
-		Start: job.Start,
-		End:   job.End,
+		Err:      err,
+		Chunk:    chunk,
+		ThreadID: job.ThreadID,
+		Start:    job.Start,
+		End:      job.End,
 	}
 }
 

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -39,11 +39,12 @@ type (
 	}
 
 	ContinuousProfileCandidate struct {
-		ProjectID  uint64 `json:"project_id"`
-		ProfilerID string `json:"profiler_id"`
-		ChunkID    string `json:"chunk_id"`
-		Start      uint64 `json:"start,string"`
-		End        uint64 `json:"end,string"`
+		ProjectID  uint64  `json:"project_id"`
+		ProfilerID string  `json:"profiler_id"`
+		ChunkID    string  `json:"chunk_id"`
+		ThreadID   *string `json:"thread_id"`
+		Start      uint64  `json:"start,string"`
+		End        uint64  `json:"end,string"`
 	}
 )
 
@@ -447,6 +448,7 @@ func GetFlamegraphFromCandidates(
 			ProjectID:      candidate.ProjectID,
 			ProfilerID:     candidate.ProfilerID,
 			ChunkID:        candidate.ChunkID,
+			ThreadID:       candidate.ThreadID,
 			Start:          candidate.Start,
 			End:            candidate.End,
 			Storage:        storage,
@@ -485,9 +487,7 @@ func GetFlamegraphFromCandidates(
 				addCallTreeToFlamegraph(&flamegraphTree, callTree, "")
 			}
 		} else if result, ok := res.(chunk.ReadJobResult); ok {
-			// TODO: this takes all threads, make sure to pass a thread id
-			// at some point to only get call trees for that thread
-			chunkCallTrees, err := result.Chunk.CallTrees(nil)
+			chunkCallTrees, err := result.Chunk.CallTrees(result.ThreadID)
 			if err != nil {
 				hub.CaptureException(err)
 				continue


### PR DESCRIPTION
This limits the calltree generated to just the selected thread for use when generating flamegraphs for a transaction/span.

Depends on getsentry/sentry#74846