### PR TITLE
ref(vroom): Use builtin min/max functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 - Filter out samples before start and after end ([#484](https://github.com/getsentry/vroom/pull/484))
 - Remove unused endpoint for profiling filters ([#485](https://github.com/getsentry/vroom/pull/485))
 - Generalize chunk task input ([#486](https://github.com/getsentry/vroom/pull/486))
+- Use builtin min/max functions ([#497](https://github.com/getsentry/vroom/pull/497))
 
 ## 23.12.0
 


### PR DESCRIPTION
Added in 1.21 and we run 1.22.5 in prod.