### PR TITLE
ref(vroom): Lift Intervals struct to utils

### DIFF
--- a/cmd/vroom/flamegraph.go
+++ b/cmd/vroom/flamegraph.go
@@ -26,7 +26,7 @@ type postFlamegraphFromProfileIDs struct {
 	// then at Span[i] we'll find a
 	// list of span intervals for the
 	// profile ProfileIDs[i]
-	Spans *[][]flamegraph.SpanInterval `json:"spans,omitempty"`
+	Spans *[][]utils.Interval `json:"spans,omitempty"`
 }
 
 func (env *environment) postFlamegraphFromProfileIDs(w http.ResponseWriter, r *http.Request) {

--- a/internal/flamegraph/span_util.go
+++ b/internal/flamegraph/span_util.go
@@ -6,15 +6,10 @@ import (
 	"time"
 
 	"github.com/getsentry/vroom/internal/nodetree"
+	"github.com/getsentry/vroom/internal/utils"
 )
 
-type SpanInterval struct {
-	Start          uint64 `json:"start,string"`
-	End            uint64 `json:"end,string"`
-	ActiveThreadID string `json:"active_thread_id"`
-}
-
-func mergeIntervals(intervals *[]SpanInterval) []SpanInterval {
+func mergeIntervals(intervals *[]utils.Interval) []utils.Interval {
 	if len(*intervals) == 0 {
 		return *intervals
 	}
@@ -25,7 +20,7 @@ func mergeIntervals(intervals *[]SpanInterval) []SpanInterval {
 		return (*intervals)[i].Start < (*intervals)[j].Start
 	})
 
-	newIntervals := []SpanInterval{(*intervals)[0]}
+	newIntervals := []utils.Interval{(*intervals)[0]}
 	for _, interval := range (*intervals)[1:] {
 		if interval.Start <= newIntervals[len(newIntervals)-1].End {
 			newIntervals[len(newIntervals)-1].End = max(newIntervals[len(newIntervals)-1].End, interval.End)
@@ -37,7 +32,7 @@ func mergeIntervals(intervals *[]SpanInterval) []SpanInterval {
 	return newIntervals
 }
 
-func relativeIntervalsFromAbsoluteTimestamp(intervals *[]SpanInterval, t uint64) {
+func relativeIntervalsFromAbsoluteTimestamp(intervals *[]utils.Interval, t uint64) {
 	for i, v := range *intervals {
 		// safety check: in case the start/end should be
 		// earlier than the profile start
@@ -46,21 +41,7 @@ func relativeIntervalsFromAbsoluteTimestamp(intervals *[]SpanInterval, t uint64)
 	}
 }
 
-func max(a, b uint64) uint64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func min(a, b uint64) uint64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func sliceCallTree(callTree *[]*nodetree.Node, intervals *[]SpanInterval) []*nodetree.Node {
+func sliceCallTree(callTree *[]*nodetree.Node, intervals *[]utils.Interval) []*nodetree.Node {
 	slicedTree := make([]*nodetree.Node, 0)
 	for _, node := range *callTree {
 		if duration := getTotalOverlappingDuration(node, intervals); duration > 0 {
@@ -82,7 +63,7 @@ func sliceCallTree(callTree *[]*nodetree.Node, intervals *[]SpanInterval) []*nod
 	return slicedTree
 }
 
-func getTotalOverlappingDuration(node *nodetree.Node, intervals *[]SpanInterval) uint64 {
+func getTotalOverlappingDuration(node *nodetree.Node, intervals *[]utils.Interval) uint64 {
 	var duration uint64
 	for _, interval := range *intervals {
 		if node.EndNS <= interval.Start {
@@ -98,7 +79,7 @@ func getTotalOverlappingDuration(node *nodetree.Node, intervals *[]SpanInterval)
 	return duration
 }
 
-func overlappingDuration(node *nodetree.Node, interval *SpanInterval) uint64 {
+func overlappingDuration(node *nodetree.Node, interval *utils.Interval) uint64 {
 	end := min(node.EndNS, interval.End)
 	start := max(node.StartNS, interval.Start)
 

--- a/internal/flamegraph/span_util_test.go
+++ b/internal/flamegraph/span_util_test.go
@@ -6,17 +6,18 @@ import (
 
 	"github.com/getsentry/vroom/internal/nodetree"
 	"github.com/getsentry/vroom/internal/testutil"
+	"github.com/getsentry/vroom/internal/utils"
 )
 
 func TestMergeIntervals(t *testing.T) {
-	inputIntervals := []SpanInterval{
+	inputIntervals := []utils.Interval{
 		{Start: 8, End: 11},
 		{Start: 3, End: 6},
 		{Start: 7, End: 12},
 		{Start: 1, End: 3},
 	}
 
-	expectedResult := []SpanInterval{
+	expectedResult := []utils.Interval{
 		{Start: 1, End: 6},
 		{Start: 7, End: 12},
 	}
@@ -32,7 +33,7 @@ func TestGetTotalOvelappingDuration(t *testing.T) {
 	tests := []struct {
 		name      string
 		node      nodetree.Node
-		intervals []SpanInterval
+		intervals []utils.Interval
 		output    uint64
 	}{
 		{
@@ -46,7 +47,7 @@ func TestGetTotalOvelappingDuration(t *testing.T) {
 				StartNS: 0,
 				EndNS:   uint64(60 * time.Millisecond),
 			},
-			intervals: []SpanInterval{
+			intervals: []utils.Interval{
 				{Start: 0, End: uint64(20 * time.Millisecond)},
 				{Start: uint64(20 * time.Millisecond), End: uint64(40 * time.Millisecond)},
 			},
@@ -63,7 +64,7 @@ func TestGetTotalOvelappingDuration(t *testing.T) {
 				StartNS: uint64(30 * time.Millisecond),
 				EndNS:   uint64(90 * time.Millisecond),
 			},
-			intervals: []SpanInterval{
+			intervals: []utils.Interval{
 				{Start: uint64(20 * time.Millisecond), End: uint64(40 * time.Millisecond)},
 				{Start: uint64(80 * time.Millisecond), End: uint64(100 * time.Millisecond)},
 			},
@@ -80,7 +81,7 @@ func TestGetTotalOvelappingDuration(t *testing.T) {
 				StartNS: 0,
 				EndNS:   uint64(80 * time.Millisecond),
 			},
-			intervals: []SpanInterval{
+			intervals: []utils.Interval{
 				{Start: uint64(20 * time.Millisecond), End: uint64(40 * time.Millisecond)},
 				{Start: uint64(90 * time.Millisecond), End: uint64(100 * time.Millisecond)},
 			},
@@ -104,7 +105,7 @@ func TestSliceCallTree(t *testing.T) {
 	tests := []struct {
 		name      string
 		callTree  []*nodetree.Node
-		intervals []SpanInterval
+		intervals []utils.Interval
 		output    []*nodetree.Node
 	}{
 		{
@@ -126,7 +127,7 @@ func TestSliceCallTree(t *testing.T) {
 					},
 				},
 			},
-			intervals: []SpanInterval{
+			intervals: []utils.Interval{
 				{Start: 0, End: uint64(100 * time.Millisecond)},
 			},
 			output: []*nodetree.Node{
@@ -170,7 +171,7 @@ func TestSliceCallTree(t *testing.T) {
 					},
 				},
 			},
-			intervals: []SpanInterval{
+			intervals: []utils.Interval{
 				{Start: uint64(10 * time.Millisecond), End: uint64(60 * time.Millisecond)},
 			},
 			output: []*nodetree.Node{
@@ -210,7 +211,7 @@ func TestSliceCallTree(t *testing.T) {
 					},
 				},
 			},
-			intervals: []SpanInterval{
+			intervals: []utils.Interval{
 				{Start: uint64(80 * time.Millisecond), End: uint64(100 * time.Millisecond)},
 			},
 			output: []*nodetree.Node{
@@ -248,7 +249,7 @@ func TestSliceCallTree(t *testing.T) {
 					},
 				},
 			},
-			intervals: []SpanInterval{
+			intervals: []utils.Interval{
 				{Start: uint64(10 * time.Millisecond), End: uint64(30 * time.Millisecond)},
 				{Start: uint64(40 * time.Millisecond), End: uint64(60 * time.Millisecond)},
 			},
@@ -285,7 +286,7 @@ func TestSliceCallTree(t *testing.T) {
 					SampleCount: 2,
 				},
 			},
-			intervals: []SpanInterval{
+			intervals: []utils.Interval{
 				{Start: uint64(250 * time.Millisecond), End: uint64(750 * time.Millisecond)},
 			},
 			output: []*nodetree.Node{

--- a/internal/utils/structs.go
+++ b/internal/utils/structs.go
@@ -1,6 +1,12 @@
 package utils
 
 type (
+	Interval struct {
+		Start          uint64 `json:"start,string"`
+		End            uint64 `json:"end,string"`
+		ActiveThreadID string `json:"active_thread_id,omitempty"`
+	}
+
 	TransactionProfileCandidate struct {
 		ProjectID uint64 `json:"project_id"`
 		ProfileID string `json:"profile_id"`


### PR DESCRIPTION
The intervals struct is generic enough to be used for all interval type data, not just for spans. One planned use case is for continuous profiling, we want to be able to slice a calltree based on an interval.