### PR TITLE
ref: optimize chunks download and fix flamegraph aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Remove module frame in python ([#496](https://github.com/getsentry/vroom/pull/496))
 - Handle js profile normalization for react+android profiles ([#499](https://github.com/getsentry/vroom/pull/499))
 - Fix metrics example list ([#505](https://github.com/getsentry/vroom/pull/505))
+- Optimize chunks download and fix flamegraph aggregation ([#508](https://github.com/getsentry/vroom/pull/508))
 
 **Internal**:
 

--- a/cmd/vroom/flamegraph.go
+++ b/cmd/vroom/flamegraph.go
@@ -215,12 +215,13 @@ func (env *environment) postFlamegraph(w http.ResponseWriter, r *http.Request) {
 		agg := metrics.NewAggregator(maxUniqueFunctionsPerProfile, 5)
 		ma = &agg
 	}
+	continuousCandidates := utils.MergeContinuousProfileCandidate(body.Continuous)
 	speedscope, err := flamegraph.GetFlamegraphFromCandidates(
 		ctx,
 		env.storage,
 		organizationID,
 		body.Transaction,
-		body.Continuous,
+		continuousCandidates,
 		readJobs,
 		ma,
 	)

--- a/internal/chunk/readjob.go
+++ b/internal/chunk/readjob.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/getsentry/vroom/internal/storageutil"
+	"github.com/getsentry/vroom/internal/utils"
 	"gocloud.dev/blob"
 )
 
@@ -19,6 +20,7 @@ type (
 		ThreadID       *string
 		Start          uint64
 		End            uint64
+		Intervals      map[string][]utils.Interval
 		Result         chan<- storageutil.ReadJobResult
 	}
 
@@ -29,6 +31,7 @@ type (
 		ThreadID      *string
 		Start         uint64
 		End           uint64
+		Intervals     map[string][]utils.Interval
 	}
 )
 
@@ -49,6 +52,7 @@ func (job ReadJob) Read() {
 		ThreadID:      job.ThreadID,
 		Start:         job.Start,
 		End:           job.End,
+		Intervals:     job.Intervals,
 	}
 }
 

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -94,7 +94,7 @@ func GetFlamegraphFromProfiles(
 					// the profile.timestamps to be consistent with the sample/node
 					// 'start' and 'end'
 					relativeIntervalsFromAbsoluteTimestamp(&spans, uint64(p.Timestamp().UnixNano()))
-					sortedSpans := mergeIntervals(&spans)
+					sortedSpans := utils.MergeIntervals(&spans)
 					for tid, callTree := range callTrees {
 						callTrees[tid] = sliceCallTree(&callTree, &sortedSpans)
 					}
@@ -572,8 +572,7 @@ func GetFlamegraphFromCandidates(
 
 			for tid, callTree := range result.CallTrees {
 				if intervals, ok := result.Intervals[tid]; ok {
-					sortedAndMergedIntervals := mergeIntervals(&intervals)
-					for _, interval := range sortedAndMergedIntervals {
+					for _, interval := range intervals {
 						intervalExample := utils.NewExampleFromProfilerChunk(
 							result.Chunk.ProjectID,
 							result.Chunk.ProfilerID,

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -586,7 +586,20 @@ func GetFlamegraphFromCandidates(
 						slicedTree := sliceCallTree(&callTree, &[]utils.Interval{interval})
 						addCallTreeToFlamegraph(&flamegraphTree, slicedTree, annotate)
 					} // end loop intervals for a given tid
-				} else { // !intervals for a tid
+				} else {
+					// if we're here it means that we don't have an interval for a given
+					// thread_id for which we generated a callTree anyway.
+					// This would happen if we received a candidate without thread_id info.
+					// In that case the call to the CallTree functions would generate a
+					// callTree for all the thread.
+					// In this case we shouldn't have any intervals (we usually receive
+					// them from chunk for which we have a transasctions) and slicing
+					// shouldn't be necessary, but for consistency and to avoid future
+					// bugs we check anyway. If there are any intervals for unspecified
+					// TIDs, those we'll be under the empty tid string "".
+					if intervals, ok := result.Intervals[""]; ok {
+						callTree = sliceCallTree(&callTree, &intervals)
+					}
 					annotate := annotateWithProfileExample(example)
 					addCallTreeToFlamegraph(&flamegraphTree, callTree, annotate)
 				}

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -572,7 +572,8 @@ func GetFlamegraphFromCandidates(
 
 			for tid, callTree := range result.CallTrees {
 				if intervals, ok := result.Intervals[tid]; ok {
-					for _, interval := range intervals {
+					sortedAndMergedIntervals := mergeIntervals(&intervals)
+					for _, interval := range sortedAndMergedIntervals {
 						intervalExample := utils.NewExampleFromProfilerChunk(
 							result.Chunk.ProjectID,
 							result.Chunk.ProfilerID,

--- a/internal/flamegraph/span_util.go
+++ b/internal/flamegraph/span_util.go
@@ -2,35 +2,11 @@ package flamegraph
 
 import (
 	"math"
-	"sort"
 	"time"
 
 	"github.com/getsentry/vroom/internal/nodetree"
 	"github.com/getsentry/vroom/internal/utils"
 )
-
-func mergeIntervals(intervals *[]utils.Interval) []utils.Interval {
-	if len(*intervals) == 0 {
-		return *intervals
-	}
-	sort.SliceStable((*intervals), func(i, j int) bool {
-		if (*intervals)[i].Start == (*intervals)[j].Start {
-			return (*intervals)[i].End < (*intervals)[j].End
-		}
-		return (*intervals)[i].Start < (*intervals)[j].Start
-	})
-
-	newIntervals := []utils.Interval{(*intervals)[0]}
-	for _, interval := range (*intervals)[1:] {
-		if interval.Start <= newIntervals[len(newIntervals)-1].End {
-			newIntervals[len(newIntervals)-1].End = max(newIntervals[len(newIntervals)-1].End, interval.End)
-		} else {
-			newIntervals = append(newIntervals, interval)
-		}
-	}
-
-	return newIntervals
-}
 
 func relativeIntervalsFromAbsoluteTimestamp(intervals *[]utils.Interval, t uint64) {
 	for i, v := range *intervals {

--- a/internal/flamegraph/span_util.go
+++ b/internal/flamegraph/span_util.go
@@ -44,7 +44,7 @@ func relativeIntervalsFromAbsoluteTimestamp(intervals *[]utils.Interval, t uint6
 func sliceCallTree(callTree *[]*nodetree.Node, intervals *[]utils.Interval) []*nodetree.Node {
 	slicedTree := make([]*nodetree.Node, 0)
 	for _, node := range *callTree {
-		newNode := node.GetShallowCopy()
+		newNode := *node
 		if duration := getTotalOverlappingDuration(node, intervals); duration > 0 {
 			sampleCount := int(math.Ceil(float64(duration) / float64(time.Millisecond*10)))
 			// here we take the minimum between the node sample count and the estimated

--- a/internal/flamegraph/span_util_test.go
+++ b/internal/flamegraph/span_util_test.go
@@ -9,26 +9,6 @@ import (
 	"github.com/getsentry/vroom/internal/utils"
 )
 
-func TestMergeIntervals(t *testing.T) {
-	inputIntervals := []utils.Interval{
-		{Start: 8, End: 11},
-		{Start: 3, End: 6},
-		{Start: 7, End: 12},
-		{Start: 1, End: 3},
-	}
-
-	expectedResult := []utils.Interval{
-		{Start: 1, End: 6},
-		{Start: 7, End: 12},
-	}
-
-	result := mergeIntervals(&inputIntervals)
-
-	if diff := testutil.Diff(result, expectedResult); diff != "" {
-		t.Fatalf("Result mismatch: got - want +\n%s", diff)
-	}
-}
-
 func TestGetTotalOvelappingDuration(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -91,7 +71,7 @@ func TestGetTotalOvelappingDuration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			intervals := mergeIntervals(&test.intervals)
+			intervals := utils.MergeIntervals(&test.intervals)
 			result := getTotalOverlappingDuration(&test.node, &intervals)
 
 			if diff := testutil.Diff(result, test.output); diff != "" {
@@ -302,7 +282,7 @@ func TestSliceCallTree(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			intervals := mergeIntervals(&test.intervals)
+			intervals := utils.MergeIntervals(&test.intervals)
 			result := sliceCallTree(&test.callTree, &intervals)
 			if diff := testutil.Diff(result, test.output); diff != "" {
 				t.Fatalf("Result mismatch: got - want +\n%s", diff)

--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -97,6 +97,25 @@ func (n *Node) WriteToHash(h hash.Hash) {
 	}
 }
 
+func (n *Node) GetShallowCopy() Node {
+	return Node{
+		Children:      n.Children,
+		DurationNS:    n.DurationNS,
+		Fingerprint:   n.Fingerprint,
+		IsApplication: n.IsApplication,
+		Line:          n.Line,
+		Name:          n.Name,
+		Package:       n.Package,
+		Path:          n.Path,
+		EndNS:         n.EndNS,
+		Frame:         n.Frame,
+		SampleCount:   n.SampleCount,
+		StartNS:       n.StartNS,
+		ProfileIDs:    n.ProfileIDs,
+		Profiles:      n.Profiles,
+	}
+}
+
 type CallTreeFunction struct {
 	Fingerprint   uint32   `json:"fingerprint"`
 	Function      string   `json:"function"`

--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -97,25 +97,6 @@ func (n *Node) WriteToHash(h hash.Hash) {
 	}
 }
 
-func (n *Node) GetShallowCopy() Node {
-	return Node{
-		Children:      n.Children,
-		DurationNS:    n.DurationNS,
-		Fingerprint:   n.Fingerprint,
-		IsApplication: n.IsApplication,
-		Line:          n.Line,
-		Name:          n.Name,
-		Package:       n.Package,
-		Path:          n.Path,
-		EndNS:         n.EndNS,
-		Frame:         n.Frame,
-		SampleCount:   n.SampleCount,
-		StartNS:       n.StartNS,
-		ProfileIDs:    n.ProfileIDs,
-		Profiles:      n.Profiles,
-	}
-}
-
 type CallTreeFunction struct {
 	Fingerprint   uint32   `json:"fingerprint"`
 	Function      string   `json:"function"`

--- a/internal/utils/struct_test.go
+++ b/internal/utils/struct_test.go
@@ -57,8 +57,7 @@ func TestMergeContinuousProfileCandidate(t *testing.T) {
 					ChunkID:    "1111",
 					Intervals: map[string][]Interval{
 						t1: {
-							{Start: 100, End: 200},
-							{Start: 200, End: 400},
+							{Start: 100, End: 400},
 						},
 						t2: {
 							{Start: 100, End: 300},
@@ -75,13 +74,65 @@ func TestMergeContinuousProfileCandidate(t *testing.T) {
 				},
 			}, // end want
 		},
+		{
+			name: "Merge candidates with overlapping time-range",
+			candidates: []ContinuousProfileCandidate{
+				{
+					ProjectID:  1,
+					ProfilerID: "1111",
+					ChunkID:    "1111",
+					ThreadID:   &t1,
+					Start:      100,
+					End:        200,
+				},
+				{
+					ProjectID:  1,
+					ProfilerID: "1111",
+					ChunkID:    "1111",
+					ThreadID:   &t1,
+					Start:      190,
+					End:        300,
+				},
+			}, // end candidates
+			want: []ContinuousProfileCandidate{
+				{
+					ProjectID:  1,
+					ProfilerID: "1111",
+					ChunkID:    "1111",
+					Intervals: map[string][]Interval{
+						t1: {
+							{Start: 100, End: 300},
+						},
+					},
+				},
+			}, // end want
+		},
 	} // end tests
 
 	for _, test := range tests {
 		newCandidates := MergeContinuousProfileCandidate(test.candidates)
-		t.Logf("%+v\n", newCandidates)
 		if diff := testutil.Diff(newCandidates, test.want); diff != "" {
 			t.Fatalf("Result mismatch: got - want +\n%s", diff)
 		}
+	}
+}
+
+func TestMergeIntervals(t *testing.T) {
+	inputIntervals := []Interval{
+		{Start: 8, End: 11},
+		{Start: 3, End: 6},
+		{Start: 7, End: 12},
+		{Start: 1, End: 3},
+	}
+
+	expectedResult := []Interval{
+		{Start: 1, End: 6},
+		{Start: 7, End: 12},
+	}
+
+	result := MergeIntervals(&inputIntervals)
+
+	if diff := testutil.Diff(result, expectedResult); diff != "" {
+		t.Fatalf("Result mismatch: got - want +\n%s", diff)
 	}
 }

--- a/internal/utils/struct_test.go
+++ b/internal/utils/struct_test.go
@@ -1,0 +1,87 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/getsentry/vroom/internal/testutil"
+)
+
+func TestMergeContinuousProfileCandidate(t *testing.T) {
+	t1 := "1"
+	t2 := "2"
+	tests := []struct {
+		name       string
+		candidates []ContinuousProfileCandidate
+		want       []ContinuousProfileCandidate
+	}{
+		{
+			name: "merge candidates",
+			candidates: []ContinuousProfileCandidate{
+				{
+					ProjectID:  1,
+					ProfilerID: "1111",
+					ChunkID:    "1111",
+					ThreadID:   &t1,
+					Start:      100,
+					End:        200,
+				},
+				{
+					ProjectID:  1,
+					ProfilerID: "2222",
+					ChunkID:    "2222",
+					ThreadID:   &t2,
+					Start:      100,
+					End:        200,
+				},
+				{
+					ProjectID:  1,
+					ProfilerID: "1111",
+					ChunkID:    "1111",
+					ThreadID:   &t1,
+					Start:      200,
+					End:        400,
+				},
+				{ // same chunkID but different threadID
+					ProjectID:  1,
+					ProfilerID: "1111",
+					ChunkID:    "1111",
+					ThreadID:   &t2,
+					Start:      100,
+					End:        300,
+				},
+			}, //end candidates
+			want: []ContinuousProfileCandidate{
+				{
+					ProjectID:  1,
+					ProfilerID: "1111",
+					ChunkID:    "1111",
+					Intervals: map[string][]Interval{
+						t1: {
+							{Start: 100, End: 200},
+							{Start: 200, End: 400},
+						},
+						t2: {
+							{Start: 100, End: 300},
+						},
+					},
+				},
+				{
+					ProjectID:  1,
+					ProfilerID: "2222",
+					ChunkID:    "2222",
+					Intervals: map[string][]Interval{t2: {
+						{Start: 100, End: 200},
+					}},
+				},
+			}, // end want
+		},
+	} // end tests
+
+	for _, test := range tests {
+		newCandidates := MergeContinuousProfileCandidate(test.candidates)
+		t.Logf("%+v\n", newCandidates)
+		if diff := testutil.Diff(newCandidates, test.want); diff != "" {
+			t.Fatalf("Result mismatch: got - want +\n%s", diff)
+		}
+	}
+}


### PR DESCRIPTION
This PR aims at improving/addressing the following:

- chunks download optimization: if in the list of `ContinuousProfilesCandidate` that we receive we have multiple candidates with the same `chunkID` we should download the same chunk only once. 
- fix aggregation bug: currently, if we receive multiple candidates with the same `chunkID` and (partially or completely) overlapping intervals, we'll end-up double counting certain functions (both for flamegraph and metrics). 