### PR TITLE
ref: re-introduce pre-commit hooks previously removed

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,14 +16,14 @@ linters:
     - gofmt
     - goimports
     #- gosec
-    #- gosimple
-    #- govet
+    - gosimple
+    - govet
     - ineffassign
     - misspell
     - nakedret
     - prealloc
     - revive
-    #- staticcheck
+    - staticcheck
     - typecheck
     - unconvert
     - unparam

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 - Use builtin min/max functions ([#497](https://github.com/getsentry/vroom/pull/497))
 - Lift Intervals struct to utils ([#498](https://github.com/getsentry/vroom/pull/498))
 - Fix flakey test for profile examples ([#504](https://github.com/getsentry/vroom/pull/504))
+- Re-introduce pre-commit hooks previously removed ([#509](https://github.com/getsentry/vroom/pull/509))
 
 ## 23.12.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/vroom
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go/storage v1.29.0


### PR DESCRIPTION
This is meant to undo changes made to `.golangci.yml` in https://github.com/getsentry/vroom/pull/507/files#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R19-R26


I've run `pre-commit run --all-files` after running both `pre-commit clean` and `pre-commit gc` to remove any cached result to confirm everything runs smooth.