### PR TITLE
chore(flamegraphs): Increase readjob channel size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Remove module frame in python ([#496](https://github.com/getsentry/vroom/pull/496))
 - Handle js profile normalization for react+android profiles ([#499](https://github.com/getsentry/vroom/pull/499))
 - Fix metrics example list ([#505](https://github.com/getsentry/vroom/pull/505))
+- Increase readjob channel size  ([#512](https://github.com/getsentry/vroom/pull/512))
 
 **Internal**:
 

--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -253,7 +253,7 @@ func main() {
 
 	slog.Info("vroom started")
 
-	readJobs = make(chan storageutil.ReadJob, env.config.WorkerPoolSize)
+	readJobs = make(chan storageutil.ReadJob, 10*env.config.WorkerPoolSize)
 	for i := 0; i < env.config.WorkerPoolSize; i++ {
 		go storageutil.ReadWorker(readJobs)
 	}


### PR DESCRIPTION
The channel size needs to be larger than the number of items or there's a risk of the channel blocking. Will rework this a little so it starts reading immediately but starting with this for now.