### PR TITLE
fix(flamegraph): Dispatch candidates using goroutine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - Remove module frame in python ([#496](https://github.com/getsentry/vroom/pull/496))
 - Handle js profile normalization for react+android profiles ([#499](https://github.com/getsentry/vroom/pull/499))
 - Fix metrics example list ([#505](https://github.com/getsentry/vroom/pull/505))
-- Increase readjob channel size  ([#512](https://github.com/getsentry/vroom/pull/512))
+- Increase readjob channel size ([#512](https://github.com/getsentry/vroom/pull/512))
 
 **Internal**:
 
@@ -102,6 +102,7 @@
 - Lift Intervals struct to utils ([#498](https://github.com/getsentry/vroom/pull/498))
 - Fix flakey test for profile examples ([#504](https://github.com/getsentry/vroom/pull/504))
 - Instrument flamegraph generation with spans ([#510](https://github.com/getsentry/vroom/pull/510)), ([#511](https://github.com/getsentry/vroom/pull/511))
+- Dispatch candidates using goroutine ([#513](https://github.com/getsentry/vroom/pull/513))
 
 ## 23.12.0
 

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -483,6 +483,8 @@ func GetFlamegraphFromCandidates(
 	results := make(chan storageutil.ReadJobResult, numCandidates)
 	defer close(results)
 
+	// We dispatch the read jobs within a goroutine so we can start reading the results
+	// immediately and NOT block until all the candidates have been dispatched.
 	go func() {
 		dispatchSpan := span.StartChild("dispatch candidates")
 		dispatchSpan.SetData("transaction_candidates", len(transactionProfileCandidates))


### PR DESCRIPTION
By dispatching candidates using a goroutine, we can immediately start reading the results of the readjobs instead of waiting until all candidates have been dispatched.