### PR TITLE
fix: Return the duration measured by the profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@
 - Annotate flamegraph with profile data ([#501](https://github.com/getsentry/vroom/pull/501)), ([#502](https://github.com/getsentry/vroom/pull/502)), ([#503](https://github.com/getsentry/vroom/pull/503))
 - Forward SDK info for sample profiles to Kafka. ([#507](https://github.com/getsentry/vroom/pull/507))
 - Forward SDK info for legacy profiles to Kafka. ([#515](https://github.com/getsentry/vroom/pull/515))
-- Return the duration measured by the profiler. ([#516](https://github.com/getsentry/vroom/pull/516))
 
 **Bug Fixes**:
 
@@ -44,6 +43,7 @@
 - Handle js profile normalization for react+android profiles ([#499](https://github.com/getsentry/vroom/pull/499))
 - Fix metrics example list ([#505](https://github.com/getsentry/vroom/pull/505))
 - Increase readjob channel size  ([#512](https://github.com/getsentry/vroom/pull/512))
+- Return the duration measured by the profiler. ([#516](https://github.com/getsentry/vroom/pull/516))
 
 **Internal**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Annotate flamegraph with profile data ([#501](https://github.com/getsentry/vroom/pull/501)), ([#502](https://github.com/getsentry/vroom/pull/502)), ([#503](https://github.com/getsentry/vroom/pull/503))
 - Forward SDK info for sample profiles to Kafka. ([#507](https://github.com/getsentry/vroom/pull/507))
 - Forward SDK info for legacy profiles to Kafka. ([#515](https://github.com/getsentry/vroom/pull/515))
+- Return the duration measured by the profiler. ([#516](https://github.com/getsentry/vroom/pull/516))
 
 **Bug Fixes**:
 

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -155,12 +155,12 @@ type AndroidEvent struct {
 
 type (
 	Android struct {
-		Clock       Clock           `json:"clock"`
-		ElapsedTime uint64          `json:"elapsed_time,omitempty"`
-		Events      []AndroidEvent  `json:"events,omitempty"`
-		Methods     []AndroidMethod `json:"methods,omitempty"`
-		StartTime   uint64          `json:"start_time,omitempty"`
-		Threads     []AndroidThread `json:"threads,omitempty"`
+		Clock         Clock           `json:"clock"`
+		ElapsedTimeUS uint64          `json:"elapsed_time,omitempty"`
+		Events        []AndroidEvent  `json:"events,omitempty"`
+		Methods       []AndroidMethod `json:"methods,omitempty"`
+		StartTime     uint64          `json:"start_time,omitempty"`
+		Threads       []AndroidThread `json:"threads,omitempty"`
 	}
 
 	Clock string
@@ -362,7 +362,7 @@ func (p Android) DurationNS() uint64 {
 	if len(p.Events) == 0 {
 		return 0
 	}
-	return p.ElapsedTime
+	return p.ElapsedTimeUS * 1e3
 }
 
 func generateFingerprint(stack []*nodetree.Node) uint64 {

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -155,11 +155,12 @@ type AndroidEvent struct {
 
 type (
 	Android struct {
-		Clock     Clock           `json:"clock"`
-		Events    []AndroidEvent  `json:"events,omitempty"`
-		Methods   []AndroidMethod `json:"methods,omitempty"`
-		StartTime uint64          `json:"start_time,omitempty"`
-		Threads   []AndroidThread `json:"threads,omitempty"`
+		Clock       Clock           `json:"clock"`
+		ElapsedTime uint64          `json:"elapsed_time,omitempty"`
+		Events      []AndroidEvent  `json:"events,omitempty"`
+		Methods     []AndroidMethod `json:"methods,omitempty"`
+		StartTime   uint64          `json:"start_time,omitempty"`
+		Threads     []AndroidThread `json:"threads,omitempty"`
 	}
 
 	Clock string
@@ -361,10 +362,7 @@ func (p Android) DurationNS() uint64 {
 	if len(p.Events) == 0 {
 		return 0
 	}
-	buildTimestamp := p.TimestampGetter()
-	startTS := buildTimestamp(p.Events[0].Time)
-	endTS := buildTimestamp(p.Events[len(p.Events)-1].Time)
-	return endTS - startTS
+	return p.ElapsedTime
 }
 
 func generateFingerprint(stack []*nodetree.Node) uint64 {

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -358,13 +358,6 @@ func (p Android) CallTreesWithMaxDepth(maxDepth int) map[uint64][]*nodetree.Node
 	return treesByThreadID
 }
 
-func (p Android) DurationNS() uint64 {
-	if len(p.Events) == 0 {
-		return 0
-	}
-	return p.ElapsedTimeUS * 1e3
-}
-
 func generateFingerprint(stack []*nodetree.Node) uint64 {
 	h := fnv.New64()
 	for _, n := range stack {

--- a/internal/profile/legacy.go
+++ b/internal/profile/legacy.go
@@ -336,7 +336,7 @@ func (p LegacyProfile) GetRetentionDays() int {
 }
 
 func (p LegacyProfile) GetDurationNS() uint64 {
-	return p.Trace.DurationNS()
+	return p.DurationNS
 }
 
 func (p LegacyProfile) GetTransactionMetadata() transaction.Metadata {

--- a/internal/profile/trace.go
+++ b/internal/profile/trace.go
@@ -9,7 +9,6 @@ type (
 	Trace interface {
 		ActiveThreadID() uint64
 		CallTrees() map[uint64][]*nodetree.Node
-		DurationNS() uint64
 		Speedscope() (speedscope.Output, error)
 	}
 )


### PR DESCRIPTION
This would use the same field for duration as https://github.com/getsentry/relay/blob/master/relay-profiling/src/android.rs#L130 which is the duration of the profile measured by the profiler https://android.googlesource.com/platform/art/+/master/runtime/trace.cc#1135.

We always set the `duration_ns` value now so I can return it directly from the metadata, not having to look through the profile.