### PR TITLE
ref: stop writing profile examples to metrics_summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 - Fix flakey test for profile examples ([#504](https://github.com/getsentry/vroom/pull/504))
 - Instrument flamegraph generation with spans ([#510](https://github.com/getsentry/vroom/pull/510)), ([#511](https://github.com/getsentry/vroom/pull/511))
 - Move calltree generation into readjob ([#514](https://github.com/getsentry/vroom/pull/514))
+- Stop writing profile examples to metrics_summary ([#519](https://github.com/getsentry/vroom/pull/519))
 
 ## 23.12.0
 


### PR DESCRIPTION
Whether we're going to store examples in `function_examples` dataset or in the existing `functions` one, we surely won't use `metrics_summary` anymore. As the profile examples data we're storing in `metrics_summary` isn't used anywhere, it's safe to be removed.