### PR TITLE
feat(flamegraph): Allow single sample stacks in flamegraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Increase readjob channel size  ([#512](https://github.com/getsentry/vroom/pull/512))
 - Return the duration measured by the profiler. ([#516](https://github.com/getsentry/vroom/pull/516), [#517](https://github.com/getsentry/vroom/pull/517))
 - Annotate functions to the right thread. ([#523](https://github.com/getsentry/vroom/pull/523))
+- Allow single sample stacks in flamegraph. ([#525](https://github.com/getsentry/vroom/pull/525))
 
 **Internal**:
 

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -600,7 +600,7 @@ func GetFlamegraphFromCandidates(
 	serializeSpan := span.StartChild("serialize")
 	defer serializeSpan.Finish()
 
-	sp := toSpeedscope(flamegraphTree, 4, 0)
+	sp := toSpeedscope(flamegraphTree, 0, 0)
 	if ma != nil {
 		fm := ma.ToMetrics()
 		sp.Metrics = &fm


### PR DESCRIPTION
This is hiding stacks from continuous profiles making for a poor onboarding experience.