### PR TITLE
feat(statistical-detectors): Handle profile chunks in regressed endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Forward SDK info for legacy profiles to Kafka. ([#515](https://github.com/getsentry/vroom/pull/515))
 - Add more metadata fields to Chunk Kafka message. ([#518](https://github.com/getsentry/vroom/pull/518))
 - Ingest Android profile chunks. ([#521](https://github.com/getsentry/vroom/pull/521))
+- Handle profile chunks in regressed endpoint. ([#527](https://github.com/getsentry/vroom/pull/527))
 
 **Bug Fixes**:
 

--- a/cmd/vroom/regressed.go
+++ b/cmd/vroom/regressed.go
@@ -25,7 +25,7 @@ func (env *environment) postRegressed(w http.ResponseWriter, r *http.Request) {
 	for _, regressedFunction := range regressedFunctions {
 		s := sentry.StartSpan(ctx, "processing")
 		s.Description = "Generating occurrence for payload"
-		occurrence, err := occurrence.ProcessRegressedFunction(ctx, env.storage, regressedFunction)
+		occurrence, err := occurrence.ProcessRegressedFunction(ctx, env.storage, regressedFunction, readJobs)
 		s.Finish()
 		if err != nil {
 			hub.CaptureException(err)

--- a/internal/chunk/android.go
+++ b/internal/chunk/android.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/getsentry/vroom/internal/clientsdk"
 	"github.com/getsentry/vroom/internal/debugmeta"
+	"github.com/getsentry/vroom/internal/frame"
 	"github.com/getsentry/vroom/internal/nodetree"
 	"github.com/getsentry/vroom/internal/platform"
 	"github.com/getsentry/vroom/internal/profile"
@@ -110,6 +111,16 @@ func (c AndroidChunk) GetOrganizationID() uint64 {
 
 func (c AndroidChunk) GetOptions() utils.Options {
 	return c.Options
+}
+
+func (c AndroidChunk) GetFrameWithFingerprint(target uint32) (frame.Frame, error) {
+	for _, m := range c.Profile.Methods {
+		f := m.Frame()
+		if f.Fingerprint() == target {
+			return f, nil
+		}
+	}
+	return frame.Frame{}, frame.ErrFrameNotFound
 }
 
 func (c *AndroidChunk) Normalize() {

--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -3,6 +3,7 @@ package chunk
 import (
 	"fmt"
 
+	"github.com/getsentry/vroom/internal/frame"
 	"github.com/getsentry/vroom/internal/platform"
 	"github.com/getsentry/vroom/internal/utils"
 )
@@ -19,6 +20,7 @@ type (
 		GetRelease() string
 		GetRetentionDays() int
 		GetOptions() utils.Options
+		GetFrameWithFingerprint(uint32) (frame.Frame, error)
 
 		DurationMS() uint64
 		EndTimestamp() float64

--- a/internal/chunk/sample.go
+++ b/internal/chunk/sample.go
@@ -252,3 +252,12 @@ func (c SampleChunk) GetOrganizationID() uint64 {
 func (c SampleChunk) GetOptions() utils.Options {
 	return c.Options
 }
+
+func (c SampleChunk) GetFrameWithFingerprint(target uint32) (frame.Frame, error) {
+	for _, f := range c.Profile.Frames {
+		if f.Fingerprint() == target {
+			return f, nil
+		}
+	}
+	return frame.Frame{}, frame.ErrFrameNotFound
+}

--- a/internal/frame/frame.go
+++ b/internal/frame/frame.go
@@ -3,6 +3,7 @@ package frame
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 	"hash/fnv"
@@ -21,6 +22,8 @@ var (
 		"Sentry": {},
 		"hermes": {},
 	}
+
+	ErrFrameNotFound = errors.New("Unable to find matching frame")
 )
 
 type (

--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -269,21 +269,6 @@ func (n *Node) Close(timestamp uint64) {
 	}
 }
 
-func (n *Node) FindNodeByFingerprint(target uint32) *Node {
-	if n.Frame.Fingerprint() == target {
-		return n
-	}
-
-	for _, child := range n.Children {
-		node := child.FindNodeByFingerprint(target)
-		if node != nil {
-			return node
-		}
-	}
-
-	return nil
-}
-
 func isSymbolicatedFrame(f frame.Frame) bool {
 	// React-native case
 	if f.Platform == platform.JavaScript && f.IsReactNative {

--- a/internal/occurrence/occurrence.go
+++ b/internal/occurrence/occurrence.go
@@ -237,7 +237,6 @@ func FromRegressedFunction(
 		EvidenceData: map[string]interface{}{
 			"organization_id": regressed.OrganizationID,
 			"project_id":      regressed.ProjectID,
-			"profile_id":      regressed.ProfileID,
 
 			// frame info
 			"file":        f.File,

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -597,3 +597,14 @@ func (p Android) ActiveThreadID() uint64 {
 	}
 	return 0
 }
+
+func (p Android) GetFrameWithFingerprint(target uint32) (frame.Frame, error) {
+	for _, m := range p.Methods {
+		f := m.Frame()
+		if f.Fingerprint() == target {
+			return f, nil
+		}
+	}
+	// TODO: handle react native
+	return frame.Frame{}, frame.ErrFrameNotFound
+}

--- a/internal/profile/legacy.go
+++ b/internal/profile/legacy.go
@@ -363,6 +363,10 @@ func (p LegacyProfile) GetOptions() utils.Options {
 	return p.Options
 }
 
+func (p LegacyProfile) GetFrameWithFingerprint(target uint32) (frame.Frame, error) {
+	return p.Trace.GetFrameWithFingerprint(target)
+}
+
 // This is to be used for ReactNative JS profile only since it works based on the
 // assumption that we'll only have 1 thread in the JS profile, as is the case
 // for ReactNative.

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/getsentry/vroom/internal/debugmeta"
+	"github.com/getsentry/vroom/internal/frame"
 	"github.com/getsentry/vroom/internal/measurements"
 	"github.com/getsentry/vroom/internal/metadata"
 	"github.com/getsentry/vroom/internal/nodetree"
@@ -42,6 +43,7 @@ type (
 		IsSampled() bool
 		SetProfileID(ID string)
 		GetOptions() utils.Options
+		GetFrameWithFingerprint(uint32) (frame.Frame, error)
 	}
 
 	Profile struct {
@@ -172,4 +174,8 @@ func (p *Profile) Measurements() map[string]measurements.Measurement {
 
 func (p *Profile) GetOptions() utils.Options {
 	return p.profile.GetOptions()
+}
+
+func (p *Profile) GetFrameWithFingerprint(target uint32) (frame.Frame, error) {
+	return p.profile.GetFrameWithFingerprint(target)
 }

--- a/internal/profile/trace.go
+++ b/internal/profile/trace.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"github.com/getsentry/vroom/internal/frame"
 	"github.com/getsentry/vroom/internal/nodetree"
 	"github.com/getsentry/vroom/internal/speedscope"
 )
@@ -10,5 +11,6 @@ type (
 		ActiveThreadID() uint64
 		CallTrees() map[uint64][]*nodetree.Node
 		Speedscope() (speedscope.Output, error)
+		GetFrameWithFingerprint(uint32) (frame.Frame, error)
 	}
 )

--- a/internal/sample/sample.go
+++ b/internal/sample/sample.go
@@ -446,6 +446,15 @@ func (p *Profile) GetOptions() utils.Options {
 	return p.Options
 }
 
+func (p *Profile) GetFrameWithFingerprint(target uint32) (frame.Frame, error) {
+	for _, f := range p.Trace.Frames {
+		if f.Fingerprint() == target {
+			return f, nil
+		}
+	}
+	return frame.Frame{}, frame.ErrFrameNotFound
+}
+
 func (t Trace) SamplesByThreadD() ([]uint64, map[uint64][]*Sample) {
 	samples := make(map[uint64][]*Sample)
 	var threadIDs []uint64


### PR DESCRIPTION
In order to support function regressions on profile chunks, we need to change from passing a simple profile id to an example metadata so we can load the chunk containing the function.