### PR TITLE
fix(profiling): Should write the profiler id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Increase readjob channel size  ([#512](https://github.com/getsentry/vroom/pull/512))
 - Return the duration measured by the profiler. ([#516](https://github.com/getsentry/vroom/pull/516), [#517](https://github.com/getsentry/vroom/pull/517))
 - Annotate functions to the right thread. ([#523](https://github.com/getsentry/vroom/pull/523))
+- Should write the profiler id. ([#528](https://github.com/getsentry/vroom/pull/528))
 
 **Internal**:
 

--- a/cmd/vroom/kafka.go
+++ b/cmd/vroom/kafka.go
@@ -100,7 +100,7 @@ func buildChunkFunctionsKafkaMessage(c *chunk.SampleChunk, functions []nodetree.
 	return FunctionsKafkaMessage{
 		Environment:            c.Environment,
 		Functions:              functions,
-		ID:                     c.ID,
+		ID:                     c.ProfilerID,
 		Platform:               c.Platform,
 		ProjectID:              c.ProjectID,
 		Received:               int64(c.Received),


### PR DESCRIPTION
When writing the id to the functions table, we should be using the profiler id not the chunk id. This means all the ids before this PR are actually all wrong.