### PR TITLE
fix: prioritize stack trace rule over app.identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Return the duration measured by the profiler. ([#516](https://github.com/getsentry/vroom/pull/516), [#517](https://github.com/getsentry/vroom/pull/517))
 - Annotate functions to the right thread. ([#523](https://github.com/getsentry/vroom/pull/523))
 - Should write the profiler id. ([#528](https://github.com/getsentry/vroom/pull/528))
+- Prioritize stack trace rule over app.identifier ([#529](https://github.com/getsentry/vroom/pull/529))
 
 **Internal**:
 

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -41,6 +41,7 @@ type (
 		DeobfuscationStatus string `json:"deobfuscation_status,omitempty"`
 		// for react-native apps where we have js frames turned into android methods
 		JsSymbolicated *bool `json:"symbolicated,omitempty"`
+		OrigiInApp     *int8 `json:"orig_in_app,omitempty"`
 	}
 )
 
@@ -374,11 +375,20 @@ func (p *Android) NormalizeMethods(pi profileInterface) {
 
 		for j := range method.InlineFrames {
 			inlineMethod := method.InlineFrames[j]
+			if inlineMethod.Data.OrigiInApp != nil {
+				continue
+			}
 
 			inApp := inlineMethod.isApplicationFrame(appIdentifier)
 			inlineMethod.InApp = &inApp
 
 			method.InlineFrames[j] = inlineMethod
+		}
+		// If a stack trace rule was applied to a given
+		// frame this should have the precedence over the
+		// appIdentifier.
+		if method.Data.OrigiInApp != nil {
+			continue
 		}
 
 		inApp := method.isApplicationFrame(appIdentifier)

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -41,7 +41,7 @@ type (
 		DeobfuscationStatus string `json:"deobfuscation_status,omitempty"`
 		// for react-native apps where we have js frames turned into android methods
 		JsSymbolicated *bool `json:"symbolicated,omitempty"`
-		OrigiInApp     *int8 `json:"orig_in_app,omitempty"`
+		OrigInApp      *int8 `json:"orig_in_app,omitempty"`
 	}
 )
 
@@ -375,7 +375,7 @@ func (p *Android) NormalizeMethods(pi profileInterface) {
 
 		for j := range method.InlineFrames {
 			inlineMethod := method.InlineFrames[j]
-			if inlineMethod.Data.OrigiInApp != nil {
+			if inlineMethod.Data.OrigInApp != nil {
 				continue
 			}
 
@@ -387,7 +387,7 @@ func (p *Android) NormalizeMethods(pi profileInterface) {
 		// If a stack trace rule was applied to a given
 		// frame this should have the precedence over the
 		// appIdentifier.
-		if method.Data.OrigiInApp != nil {
+		if method.Data.OrigInApp != nil {
 			continue
 		}
 


### PR DESCRIPTION
Whenever a frame is matched by a stack trace rule, we should prioritize the rule.

If no rule matched the frame then we can fall back on `app.identifier`.
