### PR TITLE
chore(metrics): Remove unused metrics summary kafka writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@
 - Remove generic metrics ingestion ([#534](https://github.com/getsentry/vroom/pull/534))
 - Update sentry-go dependency to v0.29.1 ([#535](https://github.com/getsentry/vroom/pull/535))
 - Lower number of concurrent reads ([#537](https://github.com/getsentry/vroom/pull/537))
+- Remove unused metrics summary kafka writer ([#538](https://github.com/getsentry/vroom/pull/538))
 
 ## 23.12.0
 

--- a/cmd/vroom/main.go
+++ b/cmd/vroom/main.go
@@ -32,9 +32,8 @@ import (
 type environment struct {
 	config ServiceConfig
 
-	occurrencesWriter   KafkaWriter
-	profilingWriter     KafkaWriter
-	metricSummaryWriter KafkaWriter
+	occurrencesWriter KafkaWriter
+	profilingWriter   KafkaWriter
 
 	storage *blob.Bucket
 }
@@ -94,10 +93,6 @@ func (e *environment) shutdown() {
 		sentry.CaptureException(err)
 	}
 	err = e.profilingWriter.Close()
-	if err != nil {
-		sentry.CaptureException(err)
-	}
-	err = e.metricSummaryWriter.Close()
 	if err != nil {
 		sentry.CaptureException(err)
 	}


### PR DESCRIPTION
This was causing vroom to panic during shutdowns.