### PR TITLE
fix: Do not report duplicate errors to Sentry

### DIFF
--- a/cmd/vroom/chunk.go
+++ b/cmd/vroom/chunk.go
@@ -99,13 +99,13 @@ func (env *environment) postChunk(w http.ResponseWriter, r *http.Request) {
 			// This is a transient error, we'll retry
 			w.WriteHeader(http.StatusTooManyRequests)
 		} else {
-			// These errors won't be retried
-			if hub != nil {
-				hub.CaptureException(err)
-			}
 			if code := gcerrors.Code(err); code == gcerrors.FailedPrecondition {
 				w.WriteHeader(http.StatusPreconditionFailed)
 			} else {
+				if hub != nil {
+					hub.CaptureException(err)
+				}
+				// These errors won't be retried
 				w.WriteHeader(http.StatusInternalServerError)
 			}
 		}

--- a/cmd/vroom/profile.go
+++ b/cmd/vroom/profile.go
@@ -90,11 +90,13 @@ func (env *environment) postProfile(w http.ResponseWriter, r *http.Request) {
 				// This is a transient error, we'll retry
 				w.WriteHeader(http.StatusTooManyRequests)
 			} else {
-				// These errors won't be retried
-				hub.CaptureException(err)
 				if code := gcerrors.Code(err); code == gcerrors.FailedPrecondition {
 					w.WriteHeader(http.StatusPreconditionFailed)
 				} else {
+					if hub != nil {
+						hub.CaptureException(err)
+					}
+					// These errors won't be retried
 					w.WriteHeader(http.StatusInternalServerError)
 				}
 			}


### PR DESCRIPTION
These errors are already monitored and counted as a metric based on the outcome we get, we don't need them as Sentry errors.

#skip-changelog