### PR TITLE
ref: add a minDepth check for function metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@
 - Remove unused chunks flamegraph endpoint ([#541](https://github.com/getsentry/vroom/pull/541))
 - Pass readjob result as pointer ([#542](https://github.com/getsentry/vroom/pull/542))
 - Bump golang.org/x/crypto from 0.24.0 to 0.31.0 ([#544](https://github.com/getsentry/vroom/pull/544))
+- Add a minDepth check for function metrics ([#550](https://github.com/getsentry/vroom/pull/550))
 
 ## 23.12.0
 

--- a/cmd/vroom/chunk.go
+++ b/cmd/vroom/chunk.go
@@ -27,6 +27,12 @@ type (
 	}
 )
 
+const (
+	// when computing slowest functions, ignore frames/node whose depth in the callTree
+	// is less than 1 (i.e. root frames).
+	minDepth uint = 1
+)
+
 func (env *environment) postChunk(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	hub := sentry.GetHubFromContext(ctx)
@@ -153,7 +159,7 @@ func (env *environment) postChunk(w http.ResponseWriter, r *http.Request) {
 	}
 	s = sentry.StartSpan(ctx, "processing")
 	s.Description = "Extract functions"
-	functions := metrics.ExtractFunctionsFromCallTrees(callTrees)
+	functions := metrics.ExtractFunctionsFromCallTrees(callTrees, minDepth)
 	functions = metrics.CapAndFilterFunctions(functions, maxUniqueFunctionsPerProfile, true)
 	s.Finish()
 

--- a/cmd/vroom/flamegraph.go
+++ b/cmd/vroom/flamegraph.go
@@ -53,7 +53,7 @@ func (env *environment) postFlamegraph(w http.ResponseWriter, r *http.Request) {
 	s = sentry.StartSpan(ctx, "processing")
 	var ma *metrics.Aggregator
 	if body.GenerateMetrics {
-		agg := metrics.NewAggregator(maxUniqueFunctionsPerProfile, 5)
+		agg := metrics.NewAggregator(maxUniqueFunctionsPerProfile, 5, minDepth)
 		ma = &agg
 	}
 	speedscope, err := flamegraph.GetFlamegraphFromCandidates(

--- a/cmd/vroom/metrics.go
+++ b/cmd/vroom/metrics.go
@@ -53,7 +53,7 @@ func (env *environment) postMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s = sentry.StartSpan(ctx, "processing")
-	ma := metrics.NewAggregator(maxUniqueFunctionsPerProfile, 5)
+	ma := metrics.NewAggregator(maxUniqueFunctionsPerProfile, 5, minDepth)
 	functionsMetrics, err := ma.GetMetricsFromCandidates(
 		ctx,
 		env.storage,

--- a/cmd/vroom/profile.go
+++ b/cmd/vroom/profile.go
@@ -156,7 +156,7 @@ func (env *environment) postProfile(w http.ResponseWriter, r *http.Request) {
 		// Prepare call trees Kafka message
 		s = sentry.StartSpan(ctx, "processing")
 		s.Description = "Extract functions"
-		functions := metrics.ExtractFunctionsFromCallTrees(callTrees)
+		functions := metrics.ExtractFunctionsFromCallTrees(callTrees, minDepth)
 		// Cap but don't filter out system frames.
 		// Necessary until front end changes are in place.
 		functionsDataset := metrics.CapAndFilterFunctions(functions, maxUniqueFunctionsPerProfile, false)

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -457,7 +457,7 @@ func GetFlamegraphFromCandidates(
 			// if metrics aggregator is not null, while we're at it,
 			// compute the metrics as well
 			if ma != nil {
-				functions := metrics.CapAndFilterFunctions(metrics.ExtractFunctionsFromCallTrees(result.CallTrees), int(ma.MaxUniqueFunctions), true)
+				functions := metrics.CapAndFilterFunctions(metrics.ExtractFunctionsFromCallTrees(result.CallTrees, ma.MinDepth), int(ma.MaxUniqueFunctions), true)
 				ma.AddFunctions(functions, example)
 			}
 
@@ -491,7 +491,7 @@ func GetFlamegraphFromCandidates(
 				// if metrics aggregator is not null, while we're at it,
 				// compute the metrics as well
 				if ma != nil {
-					functions := metrics.CapAndFilterFunctions(metrics.ExtractFunctionsFromCallTreesForThread(callTree), int(ma.MaxUniqueFunctions), true)
+					functions := metrics.CapAndFilterFunctions(metrics.ExtractFunctionsFromCallTreesForThread(callTree, ma.MinDepth), int(ma.MaxUniqueFunctions), true)
 					ma.AddFunctions(functions, example)
 				}
 			}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -64,7 +64,7 @@ func TestAggregatorAddFunctions(t *testing.T) {
 		}, // end first test
 	} // end tests list
 
-	ma := NewAggregator(100, 5)
+	ma := NewAggregator(100, 5, 0)
 	for _, test := range tests {
 		// add the same calltreeFunctions twice: once coming from a profile/chunk with
 		// ID 1 and the second one with ID 2

--- a/internal/nodetree/nodetree_test.go
+++ b/internal/nodetree/nodetree_test.go
@@ -17,6 +17,7 @@ const (
 )
 
 func TestNodeTreeCollectFunctions(t *testing.T) {
+	var minDepth uint
 	tests := []struct {
 		name     string
 		platform platform.Platform
@@ -404,7 +405,7 @@ func TestNodeTreeCollectFunctions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			results := make(map[uint32]CallTreeFunction)
-			tt.node.CollectFunctions(results, "")
+			tt.node.CollectFunctions(results, "", 0, minDepth)
 			if diff := testutil.Diff(results, tt.want); diff != "" {
 				t.Fatalf("Result mismatch: got - want +\n%s", diff)
 			}


### PR DESCRIPTION
This add a `minDepth` check that can be used to exclude certain frames from the function metrics aggregation.

Here it is set to `1`, meaning that we won't consider root frames while computing metrics aggregation and hence excluding such frames from the `slowest functions`.