### PR TITLE
fix go toolchain version syntax warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsentry/vroom
 
-go 1.21
+go 1.21.0
 
 require (
 	cloud.google.com/go/storage v1.29.0


### PR DESCRIPTION
As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).


<img width="1039" alt="Screenshot 2025-01-15 at 10 14 21" src="https://github.com/user-attachments/assets/7b011c3a-7af0-45f9-b089-eeb46113be6c" />

#skip-changelog