### PR TITLE
ci: provide arm64 image build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,28 +48,3 @@ jobs:
         go-version: stable
         cache: false
     - run: make test
-
-  publish-to-dockerhub:
-    name: Publish Vroom to DockerHub
-    runs-on: ubuntu-20.04
-    if: ${{ (github.ref_name == 'main') }}
-    steps:
-      - uses: actions/checkout@v4
-      - timeout-minutes: 20
-        run: until docker pull "us-central1-docker.pkg.dev/sentryio/vroom/vroom:${{ github.sha }}" 2>/dev/null; do sleep 10; done
-      - name: Push built docker image
-        shell: bash
-        run: |
-          IMAGE_URL="us-central1-docker.pkg.dev/sentryio/vroom/vroom:${{ github.sha }}"
-          docker login --username=sentrybuilder --password ${{ secrets.DOCKER_HUB_RW_TOKEN }}
-          # We push 3 tags to Dockerhub:
-          # first, the full sha of the commit
-          docker tag "$IMAGE_URL" getsentry/vroom:${GITHUB_SHA}
-          docker push getsentry/vroom:${GITHUB_SHA}
-          # second, the short sha of the commit
-          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
-          docker tag "$IMAGE_URL" getsentry/vroom:${SHORT_SHA}
-          docker push getsentry/vroom:${SHORT_SHA}
-          # finally, nightly
-          docker tag "$IMAGE_URL" getsentry/vroom:nightly
-          docker push getsentry/vroom:nightly

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -17,11 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      FULL_CI: true
-      # FULL_CI: "${{
-      #   github.event_name != 'pull_request'
-      #   || contains(github.event.pull_request.labels.*.name, 'Trigger: Full-CI')
-      # }}"
+      FULL_CI: "${{
+        github.event_name != 'pull_request'
+        || contains(github.event.pull_request.labels.*.name, 'Trigger: Full-CI')
+      }}"
 
     steps:
       - id: set-outputs

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -12,49 +12,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-setup:
-    name: Setup build metadata
-    runs-on: ubuntu-latest
-
-    env:
-      FULL_CI: "${{
-        github.event_name != 'pull_request'
-        || contains(github.event.pull_request.labels.*.name, 'Trigger: Full-CI')
-      }}"
-
-    steps:
-      - id: set-outputs
-        run: |
-          echo "full_ci=$FULL_CI" >> $GITHUB_OUTPUT
-
-          if [[ "$FULL_CI" == "true" ]]; then
-            echo "Running full CI"
-            echo 'archs=["amd64", "arm64"]' >> $GITHUB_OUTPUT
-          else
-            echo "Skipping some CI steps"
-            echo 'archs=["amd64"]' >> $GITHUB_OUTPUT
-          fi
-    outputs:
-      archs: "${{ steps.set-outputs.outputs.archs }}"
-      full_ci: "${{ steps.set-outputs.outputs.full_ci }}"
-
-
   build-image:
-    needs: build-setup
-
     strategy:
       matrix:
         arch: ${{ fromJson(needs.build-setup.outputs.archs) }}
-
     runs-on: |-
       ${{fromJson('{
         "amd64": "ubuntu-20.04",
         "arm64": "ubuntu-22.04-arm"
       }')[matrix.arch] }}
-
     env:
       IMG_VERSIONED: ghcr.io/getsentry/vroom:${{ matrix.arch }}-${{ github.sha }}
-
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -70,7 +41,7 @@ jobs:
               --tag "$IMG_VERSIONED" \
               .
 
-      - name: push all images
+      - name: ${{ (github.ref_name == 'main') }}
         if: "needs.build-setup.outputs.full_ci == 'true'"
         run: |
           docker push "$IMG_VERSIONED"
@@ -85,22 +56,16 @@ jobs:
 
       - name: Assemble Sha Image
         run: |
-          docker manifest create \
-            'ghcr.io/getsentry/vroom:${{ github.sha }}' \
-            'ghcr.io/getsentry/vroom:arm64-${{ github.sha }}' \
-            'ghcr.io/getsentry/vroom:amd64-${{ github.sha }}'
-
-          docker manifest push ghcr.io/getsentry/vroom:${{ github.sha }}
+          docker buildx imagetools create -t "ghcr.io/getsentry/vroom:${{ github.sha }}" \
+            "ghcr.io/getsentry/vroom:arm64-${{ github.sha }}" \
+            "ghcr.io/getsentry/vroom:amd64-${{ github.sha }}"
 
       - name: Assemble Latest Image
         if: github.ref_name == 'main'
         run: |
-          docker manifest create \
-            'ghcr.io/getsentry/vroom:latest' \
-            'ghcr.io/getsentry/vroom:arm64-${{ github.sha }}' \
-            'ghcr.io/getsentry/vroom:amd64-${{ github.sha }}'
-
-          docker manifest push ghcr.io/getsentry/vroom:latest
+          docker buildx imagetools create -t "ghcr.io/getsentry/vroom:latest" \
+            "ghcr.io/getsentry/vroom:arm64-${{ github.sha }}" \
+            "ghcr.io/getsentry/vroom:amd64-${{ github.sha }}"
 
   publish-to-dockerhub:
     name: Publish Vroom to DockerHub

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -17,10 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      FULL_CI: "${{
-        github.event_name != 'pull_request'
-        || contains(github.event.pull_request.labels.*.name, 'Trigger: Full-CI')
-      }}"
+      FULL_CI: true
+      # FULL_CI: "${{
+      #   github.event_name != 'pull_request'
+      #   || contains(github.event.pull_request.labels.*.name, 'Trigger: Full-CI')
+      # }}"
 
     steps:
       - id: set-outputs

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -15,7 +15,7 @@ jobs:
   build-image:
     strategy:
       matrix:
-        arch: ${{ fromJson(needs.build-setup.outputs.archs) }}
+        arch: [amd64, arm64]
     runs-on: |-
       ${{fromJson('{
         "amd64": "ubuntu-20.04",

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, reopened, labeled]
   push:
     branches:
-      - master
+      - main
       - release/**
 
 concurrency:
@@ -54,8 +54,6 @@ jobs:
 
     env:
       IMG_VERSIONED: ghcr.io/getsentry/vroom:${{ matrix.arch }}-${{ github.sha }}
-      NIGHTLY_IMG_CACHE: ghcr.io/getsentry/vroom:${{ matrix.arch }}-nightly
-      BUILDER_IMG_CACHE: ghcr.io/getsentry/vroom:${{ matrix.arch }}-builder
 
     steps:
       - uses: actions/checkout@v4
@@ -63,53 +61,24 @@ jobs:
       - name: Docker Login
         run: docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
 
-      - name: build builder img
+      - name: build versioned image
         run: |
           set -euxo pipefail
-          args=()
-          if docker pull -q "$BUILDER_IMG_CACHE"; then
-            args+=(--cache-from "$BUILDER_IMG_CACHE")
-          fi
           docker buildx build \
-              "${args[@]}" \
-              --build-arg BUILDKIT_INLINE_CACHE=1 \
               --build-arg TARGETARCH=${{ matrix.arch }} \
               --platform linux/${{ matrix.arch }} \
-              --tag "$BUILDER_IMG_CACHE" \
-              --target builder \
-              .
-
-      - name: build nightly img
-        run: |
-          set -euxo pipefail
-          args=()
-          if docker pull -q "$NIGHTLY_IMG_CACHE"; then
-            args+=(--cache-from "$NIGHTLY_IMG_CACHE")
-          fi
-          docker buildx build \
-              "${args[@]}" \
-              --build-arg BUILDKIT_INLINE_CACHE=1 \
-              --build-arg TARGETARCH=${{ matrix.arch }} \
-              --platform linux/${{ matrix.arch }} \
-              --tag "$NIGHTLY_IMG_CACHE" \
               --tag "$IMG_VERSIONED" \
-              --cache-from "${BUILDER_IMG_CACHE}" \
-              --cache-from "${NIGHTLY_IMG_CACHE}" \
               .
 
       - name: push all images
         if: "needs.build-setup.outputs.full_ci == 'true'"
         run: |
-          docker push "$BUILDER_IMG_CACHE"
-          docker push "$NIGHTLY_IMG_CACHE"
           docker push "$IMG_VERSIONED"
 
   assemble:
     needs: build-image
     if: github.event_name != 'pull_request'
-
     runs-on: ubuntu-20.04
-
     steps:
       - name: Docker Login
         run: docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
@@ -124,7 +93,7 @@ jobs:
           docker manifest push ghcr.io/getsentry/vroom:${{ github.sha }}
 
       - name: Assemble Latest Image
-        if: github.ref_name == 'master'
+        if: github.ref_name == 'main'
         run: |
           docker manifest create \
             'ghcr.io/getsentry/vroom:latest' \

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -73,6 +73,7 @@ jobs:
           docker buildx build \
               "${args[@]}" \
               --build-arg BUILDKIT_INLINE_CACHE=1 \
+              --build-arg TARGETARCH=${{ matrix.arch }} \
               --platform linux/${{ matrix.arch }} \
               --tag "$BUILDER_IMG_CACHE" \
               --target vroom-build \
@@ -88,6 +89,7 @@ jobs:
           docker buildx build \
               "${args[@]}" \
               --build-arg BUILDKIT_INLINE_CACHE=1 \
+              --build-arg TARGETARCH=${{ matrix.arch }} \
               --platform linux/${{ matrix.arch }} \
               --tag "$NIGHTLY_IMG_CACHE" \
               --tag "$IMG_VERSIONED" \

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,0 +1,159 @@
+name: image
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  push:
+    branches:
+      - master
+      - release/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build-setup:
+    name: Setup build metadata
+    runs-on: ubuntu-latest
+
+    env:
+      FULL_CI: "${{
+        github.event_name != 'pull_request'
+        || contains(github.event.pull_request.labels.*.name, 'Trigger: Full-CI')
+      }}"
+
+    steps:
+      - id: set-outputs
+        run: |
+          echo "full_ci=$FULL_CI" >> $GITHUB_OUTPUT
+
+          if [[ "$FULL_CI" == "true" ]]; then
+            echo "Running full CI"
+            echo 'archs=["amd64", "arm64"]' >> $GITHUB_OUTPUT
+          else
+            echo "Skipping some CI steps"
+            echo 'archs=["amd64"]' >> $GITHUB_OUTPUT
+          fi
+    outputs:
+      archs: "${{ steps.set-outputs.outputs.archs }}"
+      full_ci: "${{ steps.set-outputs.outputs.full_ci }}"
+
+
+  build-image:
+    needs: build-setup
+
+    strategy:
+      matrix:
+        arch: ${{ fromJson(needs.build-setup.outputs.archs) }}
+
+    runs-on: |-
+      ${{fromJson('{
+        "amd64": "ubuntu-20.04",
+        "arm64": "ubuntu-22.04-arm"
+      }')[matrix.arch] }}
+
+    env:
+      IMG_VERSIONED: ghcr.io/getsentry/vroom:${{ matrix.arch }}-${{ github.sha }}
+      NIGHTLY_IMG_CACHE: ghcr.io/getsentry/vroom:${{ matrix.arch }}-nightly
+      BUILDER_IMG_CACHE: ghcr.io/getsentry/vroom:${{ matrix.arch }}-builder
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker Login
+        run: docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
+
+      - name: build builder img
+        run: |
+          set -euxo pipefail
+          args=()
+          if docker pull -q "$BUILDER_IMG_CACHE"; then
+            args+=(--cache-from "$BUILDER_IMG_CACHE")
+          fi
+          docker buildx build \
+              "${args[@]}" \
+              --build-arg BUILDKIT_INLINE_CACHE=1 \
+              --platform linux/${{ matrix.arch }} \
+              --tag "$BUILDER_IMG_CACHE" \
+              --target vroom-build \
+              .
+
+      - name: build nightly img
+        run: |
+          set -euxo pipefail
+          args=()
+          if docker pull -q "$NIGHTLY_IMG_CACHE"; then
+            args+=(--cache-from "$NIGHTLY_IMG_CACHE")
+          fi
+          docker buildx build \
+              "${args[@]}" \
+              --build-arg BUILDKIT_INLINE_CACHE=1 \
+              --platform linux/${{ matrix.arch }} \
+              --tag "$NIGHTLY_IMG_CACHE" \
+              --tag "$IMG_VERSIONED" \
+              --cache-from "${BUILDER_IMG_CACHE}" \
+              --cache-from "${NIGHTLY_IMG_CACHE}" \
+              .
+
+      - name: push all images
+        if: "needs.build-setup.outputs.full_ci == 'true'"
+        run: |
+          docker push "$BUILDER_IMG_CACHE"
+          docker push "$NIGHTLY_IMG_CACHE"
+          docker push "$IMG_VERSIONED"
+
+  assemble:
+    needs: build-image
+    if: github.event_name != 'pull_request'
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Docker Login
+        run: docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
+
+      - name: Assemble Sha Image
+        run: |
+          docker manifest create \
+            'ghcr.io/getsentry/vroom:${{ github.sha }}' \
+            'ghcr.io/getsentry/vroom:arm64-${{ github.sha }}' \
+            'ghcr.io/getsentry/vroom:amd64-${{ github.sha }}'
+
+          docker manifest push ghcr.io/getsentry/vroom:${{ github.sha }}
+
+      - name: Assemble Latest Image
+        if: github.ref_name == 'master'
+        run: |
+          docker manifest create \
+            'ghcr.io/getsentry/vroom:latest' \
+            'ghcr.io/getsentry/vroom:arm64-${{ github.sha }}' \
+            'ghcr.io/getsentry/vroom:amd64-${{ github.sha }}'
+
+          docker manifest push ghcr.io/getsentry/vroom:latest
+
+  publish-to-dockerhub:
+    name: Publish Vroom to DockerHub
+    runs-on: ubuntu-20.04
+    if: ${{ (github.ref_name == 'main') }}
+    needs:
+      - assemble
+    steps:
+      - uses: actions/checkout@v4
+      - timeout-minutes: 20
+        run: until docker pull "ghcr.io/getsentry/vroom:${{ github.sha }}" 2>/dev/null; do sleep 10; done
+      - name: Push built docker image
+        shell: bash
+        run: |
+          IMAGE_URL="ghcr.io/getsentry/vroom:${{ github.sha }}"
+          docker login --username=sentrybuilder --password ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+          # We push 3 tags to Dockerhub:
+          # first, the full sha of the commit
+          docker tag "$IMAGE_URL" getsentry/vroom:${GITHUB_SHA}
+          docker push getsentry/vroom:${GITHUB_SHA}
+          # second, the short sha of the commit
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          docker tag "$IMAGE_URL" getsentry/vroom:${SHORT_SHA}
+          docker push getsentry/vroom:${SHORT_SHA}
+          # finally, nightly
+          docker tag "$IMAGE_URL" getsentry/vroom:nightly
+          docker push getsentry/vroom:nightly

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -76,7 +76,7 @@ jobs:
               --build-arg TARGETARCH=${{ matrix.arch }} \
               --platform linux/${{ matrix.arch }} \
               --tag "$BUILDER_IMG_CACHE" \
-              --target vroom-build \
+              --target builder \
               .
 
       - name: build nightly img

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -41,8 +41,8 @@ jobs:
               --tag "$IMG_VERSIONED" \
               .
 
-      - name: ${{ (github.ref_name == 'main') }}
-        if: "needs.build-setup.outputs.full_ci == 'true'"
+      - name: push image to ghcr
+        if: ${{ (github.ref_name == 'main') }}
         run: |
           docker push "$IMG_VERSIONED"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@
 - Pass readjob result as pointer ([#542](https://github.com/getsentry/vroom/pull/542))
 - Bump golang.org/x/crypto from 0.24.0 to 0.31.0 ([#544](https://github.com/getsentry/vroom/pull/544))
 - Add a minDepth check for function metrics ([#550](https://github.com/getsentry/vroom/pull/550))
+- Provide ARM64 image build ([#552](https://github.com/getsentry/vroom/pull/552))
 
 ## 23.12.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 ARG GOVERSION=latest
+ARG TARGETARCH=amd64
 FROM golang:$GOVERSION AS builder
 
 WORKDIR /src
 COPY . .
 
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o . -ldflags="-s -w -X main.release=$(git rev-parse HEAD)" ./cmd/vroom
+RUN GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=0 go build -o . -ldflags="-s -w -X main.release=$(git rev-parse HEAD)" ./cmd/vroom
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
Effort for https://github.com/getsentry/self-hosted/issues/1585

The GCB pipeline that build the image and push it to GCR will still be run, but for DockerHub, we'll take the image from GHCR (GitHub Container Registry) instead. This PR will provide ARM64 version available on GHCR and DockerHub.

Also see the comment on snuba PR, we were talking about building it once and mirroring that image everywhere (build on GitHub Actions, push to GitHub Container Registry, DockerHub and GCR): https://github.com/getsentry/snuba/pull/6800#issuecomment-2609942893

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
