### PR TITLE
fix android callTree timestamps and make them consistent with the sample (v2) format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Annotate functions to the right thread. ([#523](https://github.com/getsentry/vroom/pull/523))
 - Should write the profiler id. ([#528](https://github.com/getsentry/vroom/pull/528))
 - Prioritize stack trace rule over app.identifier ([#529](https://github.com/getsentry/vroom/pull/529))
+- Fix android callTree timestamps and make them consistent with the sample (v2) format ([#553](https://github.com/getsentry/vroom/pull/553))
 
 **Internal**:
 

--- a/internal/chunk/android.go
+++ b/internal/chunk/android.go
@@ -55,6 +55,7 @@ func (c AndroidChunk) DurationMS() uint64 {
 }
 
 func (c AndroidChunk) CallTrees(_ *string) (map[string][]*nodetree.Node, error) {
+	c.Profile.SdkStartTime = uint64(c.StartTimestamp() * 1e9)
 	callTrees := c.Profile.CallTrees()
 	stringThreadCallTrees := make(map[string][]*nodetree.Node)
 	for tid, callTree := range callTrees {

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -161,7 +161,9 @@ type (
 		Events    []AndroidEvent  `json:"events,omitempty"`
 		Methods   []AndroidMethod `json:"methods,omitempty"`
 		StartTime uint64          `json:"start_time,omitempty"`
-		// SdkStartTime, if set, it's an absolute ts in Ns set by the sentry SDK
+		// SdkStartTime, if set (manually), it's an absolute ts in Ns
+		// whose value comes from the chunk timestamp set by the sentry SDK.
+		// This is used to control the ts during callTree generation.
 		SdkStartTime uint64          `json:"-"`
 		Threads      []AndroidThread `json:"threads,omitempty"`
 	}

--- a/internal/profile/android.go
+++ b/internal/profile/android.go
@@ -161,7 +161,9 @@ type (
 		Events    []AndroidEvent  `json:"events,omitempty"`
 		Methods   []AndroidMethod `json:"methods,omitempty"`
 		StartTime uint64          `json:"start_time,omitempty"`
-		Threads   []AndroidThread `json:"threads,omitempty"`
+		// SdkStartTime, if set, it's an absolute ts in Ns set by the sentry SDK
+		SdkStartTime uint64          `json:"-"`
+		Threads      []AndroidThread `json:"threads,omitempty"`
 	}
 
 	Clock string
@@ -343,7 +345,7 @@ func (p Android) CallTreesWithMaxDepth(maxDepth int) map[uint64][]*nodetree.Node
 			continue
 		}
 
-		ts := buildTimestamp(e.Time)
+		ts := buildTimestamp(e.Time) + p.SdkStartTime
 		if ts > maxTimestampNS {
 			maxTimestampNS = ts
 		}


### PR DESCRIPTION
Android and sample format share the same CallTree struct. 
While the sample format (`v2`) set the `ts` of the nodes to as absolute `ts`, the android one is setting a relative one.
This break the callTree slicing.

An optional `SdkStartTime` has been added to optionally convert the `ts` to absolute ones.

For legacy android profiles we won't set it, hence it'll keep the relative ones.



