### PR TITLE
ref: use generic Chunk interface in CallTreesReadJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Handle profile chunks in regressed endpoint. ([#527](https://github.com/getsentry/vroom/pull/527))
 - Authentication support for Kafka connection. ([#530](https://github.com/getsentry/vroom/pull/530))
 - Add support for android chunks. ([#540](https://github.com/getsentry/vroom/pull/540))
+- Use generic Chunk interface in CallTreesReadJob ([#554](https://github.com/getsentry/vroom/pull/554))
 
 **Bug Fixes**:
 

--- a/internal/chunk/sample_readjob.go
+++ b/internal/chunk/sample_readjob.go
@@ -63,7 +63,7 @@ type (
 	CallTreesReadJobResult struct {
 		Err           error
 		CallTrees     map[string][]*nodetree.Node
-		Chunk         *SampleChunk
+		Chunk         *Chunk
 		TransactionID string
 		ThreadID      *string
 		Start         uint64
@@ -72,7 +72,7 @@ type (
 )
 
 func (job CallTreesReadJob) Read() {
-	var chunk SampleChunk
+	var chunk Chunk
 
 	err := storageutil.UnmarshalCompressed(
 		job.Ctx,

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -476,9 +476,9 @@ func GetFlamegraphFromCandidates(
 				}
 
 				example := utils.NewExampleFromProfilerChunk(
-					result.Chunk.ProjectID,
-					result.Chunk.ProfilerID,
-					result.Chunk.ID,
+					result.Chunk.GetProjectID(),
+					result.Chunk.GetProfilerID(),
+					result.Chunk.GetID(),
 					result.TransactionID,
 					&threadID,
 					result.Start,


### PR DESCRIPTION
`CallTreesReadJob` was still using `sample` specific struct to deserialize the chunk.

With this we're going to use a `Chunk` interface and supporting `AndroidChunk` as well.
