### PR TITLE
ci: run release action only on getsentry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: "Release a new vroom version"
+    if: github.repository_owner == 'getsentry'
     steps:
       - name: Get auth token
         id: token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 - Bump x/net package to fix security issue (high severity) ([#555](https://github.com/getsentry/vroom/pull/555))
 - Enforce shorter timeout for chunks download in flamegraph generation ([#557](https://github.com/getsentry/vroom/pull/557))
 - Bump actions/create-github-app-token from 1.11.2 to 1.11.3 ([#559](https://github.com/getsentry/vroom/pull/559))
+- Run release action only on getsentry ([#561](https://github.com/getsentry/vroom/pull/561))
 
 ## 23.12.0
 


### PR DESCRIPTION
Not much impact for now. This shouldn't be triggered on fork repositories. If someone change this file to the wrong direction, at least it'll be some kind of another safety layer.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
