### PR TITLE
return different flamechart data under the same chunk field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # IDE
 .vscode/
+
+.DS_Store

--- a/cmd/vroom/chunk.go
+++ b/cmd/vroom/chunk.go
@@ -208,7 +208,7 @@ type postProfileFromChunkIDsRequest struct {
 // This way, if we decide to later add a few more utility fields
 // (for pagination, etc.) we won't have to change the Chunk struct.
 type postProfileFromChunkIDsResponse struct {
-	Chunk chunk.SampleChunk `json:"chunk"`
+	Chunk interface{} `json:"chunk"`
 }
 
 // This is more of a GET method, but since we're receiving a list of chunk IDs as part of a
@@ -371,7 +371,7 @@ func (env *environment) postProfileFromChunkIDs(w http.ResponseWriter, r *http.R
 			return
 		}
 		s = sentry.StartSpan(ctx, "json.marshal")
-		resp, err = json.Marshal(sp)
+		resp, err = json.Marshal(postProfileFromChunkIDsResponse{Chunk: sp})
 		s.Finish()
 		if err != nil {
 			hub.CaptureException(err)


### PR DESCRIPTION
Both for V2 (merged chunk) and for android (speedscope) we'll return the flamechart data under the `chunk` field.

#skip-changelog