### PR TITLE
ref: refactor speedscope struct

### DIFF
--- a/internal/chunk/android_utils.go
+++ b/internal/chunk/android_utils.go
@@ -174,7 +174,7 @@ func SpeedscopeFromAndroidChunks(chunks []AndroidChunk, startTS, endTS uint64) (
 	s.Metadata.Timestamp = time.Unix(0, int64(firstChunkStartTimestampNS)).UTC()
 
 	if len(mergedMeasurement) > 0 {
-		s.MeasurementsV2 = mergedMeasurement
+		s.Measurements = mergedMeasurement
 	}
 
 	return s, nil

--- a/internal/chunk/android_utils.go
+++ b/internal/chunk/android_utils.go
@@ -172,6 +172,7 @@ func SpeedscopeFromAndroidChunks(chunks []AndroidChunk, startTS, endTS uint64) (
 	}
 	s.DurationNS = chunk.DurationNS
 	s.Metadata.Timestamp = time.Unix(0, int64(firstChunkStartTimestampNS)).UTC()
+	s.ChunkID = chunk.ID
 
 	if len(mergedMeasurement) > 0 {
 		s.Measurements = mergedMeasurement

--- a/internal/chunk/android_utils_test.go
+++ b/internal/chunk/android_utils_test.go
@@ -12,6 +12,7 @@ import (
 var androidChunk1 = AndroidChunk{
 	Timestamp:  0.0,
 	DurationNS: 1500,
+	ID:         "1a009sd87",
 	Profile: profile.Android{
 		Clock: "Dual",
 		Events: []profile.AndroidEvent{
@@ -101,6 +102,7 @@ var androidChunk1 = AndroidChunk{
 var androidChunk2 = AndroidChunk{
 	Timestamp:  2.5e-6,
 	DurationNS: 2000,
+	ID:         "ee3409d8",
 	Profile: profile.Android{
 		Clock: "Dual",
 		Events: []profile.AndroidEvent{
@@ -201,6 +203,7 @@ func TestSpeedscopeFromAndroidChunks(t *testing.T) {
 			want: speedscope.Output{
 				AndroidClock: "Dual",
 				DurationNS:   4500,
+				ChunkID:      "1a009sd87",
 				Profiles: []any{
 					&speedscope.EventedProfile{
 						EndValue: 4500,
@@ -276,6 +279,7 @@ func TestSpeedscopeFromAndroidChunks(t *testing.T) {
 			want: speedscope.Output{
 				AndroidClock: "Dual",
 				DurationNS:   3000,
+				ChunkID:      "1a009sd87",
 				Profiles: []any{
 					&speedscope.EventedProfile{
 						EndValue: 3000,

--- a/internal/speedscope/speedscope.go
+++ b/internal/speedscope/speedscope.go
@@ -96,6 +96,7 @@ type (
 		Metadata           ProfileMetadata          `json:"metadata"`
 		Platform           platform.Platform        `json:"platform"`
 		ProfileID          string                   `json:"profileID,omitempty"`
+		ChunkID            string                   `json:"chunkID,omitempty"`
 		Profiles           []interface{}            `json:"profiles"`
 		ProjectID          uint64                   `json:"projectID"`
 		Shared             SharedData               `json:"shared"`

--- a/internal/speedscope/speedscope.go
+++ b/internal/speedscope/speedscope.go
@@ -88,21 +88,20 @@ type (
 	ValueUnit   string
 
 	Output struct {
-		ActiveProfileIndex int                                   `json:"activeProfileIndex"`
-		AndroidClock       string                                `json:"androidClock,omitempty"`
-		DurationNS         uint64                                `json:"durationNS,omitempty"`
-		Images             []debugmeta.Image                     `json:"images,omitempty"`
-		Measurements       map[string]measurements.Measurement   `json:"measurements,omitempty"`
-		MeasurementsV2     map[string]measurements.MeasurementV2 `json:"measurements_v2,omitempty"`
-		Metadata           ProfileMetadata                       `json:"metadata"`
-		Platform           platform.Platform                     `json:"platform"`
-		ProfileID          string                                `json:"profileID,omitempty"`
-		Profiles           []interface{}                         `json:"profiles"`
-		ProjectID          uint64                                `json:"projectID"`
-		Shared             SharedData                            `json:"shared"`
-		TransactionName    string                                `json:"transactionName"`
-		Version            string                                `json:"version,omitempty"`
-		Metrics            *[]utils.FunctionMetrics              `json:"metrics"`
+		ActiveProfileIndex int                      `json:"activeProfileIndex"`
+		AndroidClock       string                   `json:"androidClock,omitempty"`
+		DurationNS         uint64                   `json:"durationNS,omitempty"`
+		Images             []debugmeta.Image        `json:"images,omitempty"`
+		Measurements       interface{}              `json:"measurements,omitempty"`
+		Metadata           ProfileMetadata          `json:"metadata"`
+		Platform           platform.Platform        `json:"platform"`
+		ProfileID          string                   `json:"profileID,omitempty"`
+		Profiles           []interface{}            `json:"profiles"`
+		ProjectID          uint64                   `json:"projectID"`
+		Shared             SharedData               `json:"shared"`
+		TransactionName    string                   `json:"transactionName"`
+		Version            string                   `json:"version,omitempty"`
+		Metrics            *[]utils.FunctionMetrics `json:"metrics"`
 	}
 
 	ProfileMetadata struct {


### PR DESCRIPTION
Return all the measurements (V2 and legacy) under the `measurements` field (dropping _measurement_v2_) and add a `chunkID`, similarly to the `profileID` to discern between legacy profiling and continuous profiling.


#skip-changelog