### PR TITLE
feat(flamegraph): Add start/end to profile example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Authentication support for Kafka connection. ([#530](https://github.com/getsentry/vroom/pull/530))
 - Add support for android chunks. ([#540](https://github.com/getsentry/vroom/pull/540))
 - Use generic Chunk interface in CallTreesReadJob ([#554](https://github.com/getsentry/vroom/pull/554))
+- Add start/end to profile example. ([#575](https://github.com/getsentry/vroom/pull/575))
 
 **Bug Fixes**:
 

--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -454,7 +454,13 @@ func GetFlamegraphFromCandidates(
 			transactionProfileSpan := span.StartChild("calltree")
 			transactionProfileSpan.Description = "transaction profile"
 
-			example := utils.NewExampleFromProfileID(result.Profile.ProjectID(), result.Profile.ID())
+			start, end := result.Profile.StartAndEndEpoch()
+			example := utils.NewExampleFromProfileID(
+				result.Profile.ProjectID(),
+				result.Profile.ID(),
+				start,
+				end,
+			)
 			annotate := annotateWithProfileExample(example)
 
 			for _, callTree := range result.CallTrees {

--- a/internal/flamegraph/flamegraph_test.go
+++ b/internal/flamegraph/flamegraph_test.go
@@ -247,7 +247,7 @@ func TestAnnotatingWithExamples(t *testing.T) {
 				},
 			},
 			examples: []utils.ExampleMetadata{
-				utils.NewExampleFromProfileID(1, "2"),
+				utils.NewExampleFromProfileID(1, "2", 10_000_000, 50_000_000),
 				utils.NewExampleFromProfilerChunk(3, "4", "5", "6", &threadID, 10_000_000, 50_000_000),
 			},
 			output: speedscope.Output{
@@ -282,6 +282,8 @@ func TestAnnotatingWithExamples(t *testing.T) {
 						{
 							ProjectID: 1,
 							ProfileID: "2",
+							Start:     0.01,
+							End:       0.05,
 						},
 						{
 							ProjectID:     3,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -256,7 +256,13 @@ func (ma *Aggregator) GetMetricsFromCandidates(
 				hub.CaptureException(err)
 				continue
 			}
-			resultMetadata = utils.NewExampleFromProfileID(result.Profile.ProjectID(), result.Profile.ID())
+			start, end := result.Profile.StartAndEndEpoch()
+			resultMetadata = utils.NewExampleFromProfileID(
+				result.Profile.ProjectID(),
+				result.Profile.ID(),
+				start,
+				end,
+			)
 			functions := CapAndFilterFunctions(ExtractFunctionsFromCallTrees(profileCallTrees, ma.MinDepth), int(ma.MaxUniqueFunctions), true)
 			ma.AddFunctions(functions, resultMetadata)
 		} else if result, ok := res.(chunk.ReadJobResult); ok {

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -136,6 +136,12 @@ func (p *Profile) Timestamp() time.Time {
 	return p.profile.GetTimestamp()
 }
 
+func (p *Profile) StartAndEndEpoch() (uint64, uint64) {
+	startEpoch := uint64(p.Timestamp().UnixNano())
+	duration := p.DurationNS()
+	return startEpoch, startEpoch + duration
+}
+
 func (p *Profile) Received() time.Time {
 	return p.profile.GetReceived()
 }

--- a/internal/utils/structs.go
+++ b/internal/utils/structs.go
@@ -56,10 +56,14 @@ type (
 func NewExampleFromProfileID(
 	projectID uint64,
 	profileID string,
+	start uint64,
+	end uint64,
 ) ExampleMetadata {
 	return ExampleMetadata{
 		ProjectID: projectID,
 		ProfileID: profileID,
+		Start:     float64(start) / 1e9,
+		End:       float64(end) / 1e9,
 	}
 }
 


### PR DESCRIPTION
Previously, only chunk examples had start/end associated with it. There's no reason why profile examples can't have them so make sure they're added so it can be used by the UI.