### PR TITLE
ci: publish vroom to GHCR and provide a tagged release on GHCR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,31 @@ jobs:
         cache: false
     - run: make test
 
+  publish-to-ghcr:
+    name: Publish Vroom to GHCR
+    runs-on: ubuntu-20.04
+    if: ${{ (github.ref_name == 'main') }}
+    steps:
+      - uses: actions/checkout@v4
+      - timeout-minutes: 20
+        run: until docker pull "us-central1-docker.pkg.dev/sentryio/vroom/vroom:${{ github.sha }}" 2>/dev/null; do sleep 10; done
+      - name: Push built docker image
+        shell: bash
+        run: |
+          IMAGE_URL="us-central1-docker.pkg.dev/sentryio/vroom/vroom:${{ github.sha }}"
+          docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
+          # We push 3 tags to GHCR:
+          # first, the full sha of the commit
+          docker tag "$IMAGE_URL" ghcr.io/getsentry/vroom:${GITHUB_SHA}
+          docker push ghcr.io/getsentry/vroom:${GITHUB_SHA}
+          # second, the short sha of the commit
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          docker tag "$IMAGE_URL" ghcr.io/getsentry/vroom:${SHORT_SHA}
+          docker push ghcr.io/getsentry/vroom:${SHORT_SHA}
+          # finally, nightly
+          docker tag "$IMAGE_URL" ghcr.io/getsentry/vroom:nightly
+          docker push ghcr.io/getsentry/vroom:nightly
+
   publish-to-dockerhub:
     name: Publish Vroom to DockerHub
     runs-on: ubuntu-20.04

--- a/.github/workflows/release-ghcr-version-tag.yaml
+++ b/.github/workflows/release-ghcr-version-tag.yaml
@@ -1,0 +1,22 @@
+name: Release GHCR Versioned Image
+
+on:
+  release:
+    types: [prereleased, released]
+
+jobs:
+  release-ghcr-version-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag release version
+        run: |
+          docker buildx imagetools create --tag \
+           ghcr.io/getsentry/vroom:${{ github.ref_name }} \
+           ghcr.io/getsentry/vroom:${{ github.sha }}


### PR DESCRIPTION
Similar work with these PRs:

- https://github.com/getsentry/relay/pull/4532
- https://github.com/getsentry/symbolicator/pull/1635
- https://github.com/getsentry/snuba/pull/6997
- https://github.com/getsentry/sentry/pull/88181

While also trying to provide a solution (or at least an alternative) for this issue: https://github.com/getsentry/self-hosted/issues/3593


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
