### PR TITLE
chore(flamegraph): Buffer flamegraph candidates to reduce memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@
 - Bump x/net package to fix security issue (high severity) ([#555](https://github.com/getsentry/vroom/pull/555))
 - Enforce shorter timeout for chunks download in flamegraph generation ([#557](https://github.com/getsentry/vroom/pull/557))
 - Bump actions/create-github-app-token from 1.11.2 to 1.11.3 ([#559](https://github.com/getsentry/vroom/pull/559))
+- Buffer flamegraph candidates to reduce memory usage. ([#583](https://github.com/getsentry/vroom/pull/583))
 
 ## 23.12.0
 


### PR DESCRIPTION
This buffers the profile candidates after they're read to prevent all of them being held in memory at the same time.