### PR TITLE
chore(profiling): Reduce Read jobs buffer to reduce memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
 - Enforce shorter timeout for chunks download in flamegraph generation ([#557](https://github.com/getsentry/vroom/pull/557))
 - Bump actions/create-github-app-token from 1.11.2 to 1.11.3 ([#559](https://github.com/getsentry/vroom/pull/559))
 - Buffer flamegraph candidates to reduce memory usage. ([#583](https://github.com/getsentry/vroom/pull/583))
+- Reduce read jobs buffer to reduce memory usage. ([#584](https://github.com/getsentry/vroom/pull/584))
 
 ## 23.12.0
 

--- a/cmd/vroom/chunk.go
+++ b/cmd/vroom/chunk.go
@@ -254,18 +254,21 @@ func (env *environment) postProfileFromChunkIDs(w http.ResponseWriter, r *http.R
 
 	results := make(chan storageutil.ReadJobResult, len(requestBody.ChunkIDs))
 	defer close(results)
+
 	// send a task to the workers pool for each chunk
-	for _, ID := range requestBody.ChunkIDs {
-		readJobs <- chunk.ReadJob{
-			Ctx:            ctx,
-			Storage:        env.storage,
-			OrganizationID: organizationID,
-			ProjectID:      projectID,
-			ProfilerID:     requestBody.ProfilerID,
-			ChunkID:        ID,
-			Result:         results,
+	go func() {
+		for _, ID := range requestBody.ChunkIDs {
+			readJobs <- chunk.ReadJob{
+				Ctx:            ctx,
+				Storage:        env.storage,
+				OrganizationID: organizationID,
+				ProjectID:      projectID,
+				ProfilerID:     requestBody.ProfilerID,
+				ChunkID:        ID,
+				Result:         results,
+			}
 		}
-	}
+	}()
 
 	chunks := make([]chunk.Chunk, 0, len(requestBody.ChunkIDs))
 	// read the output of each tasks

--- a/cmd/vroom/config.go
+++ b/cmd/vroom/config.go
@@ -4,7 +4,7 @@ type (
 	ServiceConfig struct {
 		Environment    string `env:"SENTRY_ENVIRONMENT" env-default:"development"`
 		Port           int    `env:"PORT"               env-default:"8085"`
-		WorkerPoolSize int    `env:"WORKER_POOL_SIZE"               env-default:"25"`
+		WorkerPoolSize int    `env:"WORKER_POOL_SIZE"               env-default:"10"`
 
 		SentryDSN string `env:"SENTRY_DSN"`
 


### PR DESCRIPTION
Previously buffered the results on flamegraph endpoint. This makes the results a buffered channel in all places and lowers the number of workers in an attempt to lower the memory usage further.