### PR TITLE
fix: update deprecated/unsupported ubuntu runner image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
 
   publish-to-dockerhub:
     name: Publish Vroom to DockerHub
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ (github.ref_name == 'main') }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 20.04 has been completely unsupported since 2025-04-15 and this has caused our "Publish Vroom to Dockerhub" job to fail since then. 
Here we set the image to ubuntu-latest as it is for the other jobs.



See: https://github.com/actions/runner-images/issues/11101