### PR TITLE
ci: create one manifest at a time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,12 +130,19 @@ jobs:
           docker push ghcr.io/getsentry/vroom:${{ github.sha }}-amd64
           docker tag vroom:arm64 ghcr.io/getsentry/vroom:${{ github.sha }}-arm64
           docker push ghcr.io/getsentry/vroom:${{ github.sha }}-arm64
+
           docker manifest create \
             ghcr.io/getsentry/vroom:${{ github.sha }} \
+            --amend ghcr.io/getsentry/vroom:${{ github.sha }}-amd64 \
+            --amend ghcr.io/getsentry/vroom:${{ github.sha }}-arm64
+
+          docker manifest create \
             ghcr.io/getsentry/vroom:nightly \
             --amend ghcr.io/getsentry/vroom:${{ github.sha }}-amd64 \
             --amend ghcr.io/getsentry/vroom:${{ github.sha }}-arm64
+
           docker manifest push ghcr.io/getsentry/vroom:${{ github.sha }}
+          docker manifest push ghcr.io/getsentry/vroom:nightly
 
   publish-to-dockerhub:
     name: Publish Vroom to DockerHub


### PR DESCRIPTION
Fixes https://github.com/getsentry/vroom/actions/runs/15611124623/job/43972275881

#skip-changelog

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
