### PR TITLE
ci: correctly push multiplatform image to dockerhub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,6 +161,7 @@ jobs:
           
           # We push 3 tags to Dockerhub:
           # first, the full sha of the commit
+          GITHUB_SHA="${{ github.sha }}"
           docker buildx imagetools create --tag getsentry/vroom:${GITHUB_SHA} ghcr.io/getsentry/vroom:${{ github.sha }}
           
           # second, the short sha of the commit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,14 +158,14 @@ jobs:
           IMAGE_URL="ghcr.io/getsentry/vroom:${{ github.sha }}"
           docker pull "$IMAGE_URL"
           docker login --username=sentrybuilder --password ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+          
           # We push 3 tags to Dockerhub:
           # first, the full sha of the commit
-          docker tag "$IMAGE_URL" getsentry/vroom:${GITHUB_SHA}
-          docker push getsentry/vroom:${GITHUB_SHA}
+          docker buildx imagetools create --tag getsentry/vroom:${GITHUB_SHA} ghcr.io/getsentry/vroom:${{ github.sha }}
+          
           # second, the short sha of the commit
           SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
-          docker tag "$IMAGE_URL" getsentry/vroom:${SHORT_SHA}
-          docker push getsentry/vroom:${SHORT_SHA}
+          docker buildx imagetools create --tag getsentry/vroom:${SHORT_SHA} ghcr.io/getsentry/vroom:${{ github.sha }}
+
           # finally, nightly
-          docker tag "$IMAGE_URL" getsentry/vroom:nightly
-          docker push getsentry/vroom:nightly
+          docker buildx imagetools create --tag getsentry/vroom:nightly ghcr.io/getsentry/vroom:${{ github.sha }}


### PR DESCRIPTION
This was missing. Copying what relay did here: https://github.com/getsentry/relay/blob/7f4b354ebb99286dd20ee34c1da4540f7e1135bd/.github/workflows/ci.yml#L579-L594

#skip-changelog

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
