### PR TITLE
Revert "feat(docker): add default non-root user"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@
 - Add support for android chunks. ([#540](https://github.com/getsentry/vroom/pull/540))
 - Use generic Chunk interface in CallTreesReadJob ([#554](https://github.com/getsentry/vroom/pull/554))
 - Add start/end to profile example. ([#575](https://github.com/getsentry/vroom/pull/575))
-- Add default non-root user in the Docker image. ([#593](https://github.com/getsentry/vroom/pull/593))
 
 **Bug Fixes**:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,7 @@ EXPOSE 8080
 
 ARG PROFILES_DIR=/var/lib/sentry-profiles
 
-RUN groupadd --gid 1000 vroom \
-    && useradd -g vroom --uid 1000 vroom \
-    && apt-get update \
+RUN apt-get update \
     && apt-get install -y ca-certificates tzdata --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
@@ -25,7 +23,5 @@ ENV SENTRY_BUCKET_PROFILES=file://localhost/$PROFILES_DIR
 COPY --from=builder /src/vroom /bin/vroom
 
 WORKDIR /var/vroom
-
-USER vroom
 
 ENTRYPOINT ["/bin/vroom"]


### PR DESCRIPTION
Reverts getsentry/vroom#593

This PR introduces changes that break self-hosted, integrations tests fail unless using a vroom image that is prior to this PR going in

https://github.com/getsentry/self-hosted/pull/3752/commits/efd50f13b3a0b3b3ab78579fac9840bb5a4e27dd

#skip-changelog