### PR TITLE
ref(gocd): update scripts to use console script entry points

### DIFF
--- a/gocd/templates/bash/check-cloudbuild.sh
+++ b/gocd/templates/bash/check-cloudbuild.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/googlecloud/check_cloudbuild.py \
+checks-googlecloud-check-cloudbuild \
 	sentryio \
 	vroom \
 	build-vroom \

--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/githubactions/checkruns.py \
+checks-githubactions-checkruns \
 	getsentry/vroom \
 	${GO_REVISION_VROOM_REPO} \
 	test-vroom

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel
-/devinfra/scripts/k8s/k8s-deploy.py \
+k8s-deploy \
 	--label-selector="${LABEL_SELECTOR}" \
 	--image="us-central1-docker.pkg.dev/sentryio/vroom/vroom:${GO_REVISION_VROOM_REPO}" \
 	--container-name="vroom"

--- a/gocd/templates/bash/wait-canary.sh
+++ b/gocd/templates/bash/wait-canary.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-/devinfra/scripts/canary/canarychecks.py \
+checks-canary-canarychecks \
   --skip-check=${SKIP_CANARY_CHECKS} \
   --wait-minutes=5


### PR DESCRIPTION

Updating gocd scripts to use console script entry points.

Please see: https://github.com/getsentry/devinfra-deployment-service/pull/698
