### PR TITLE
feat(flamegraph): Return number of occurrences in flamegraph per frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 - Add start/end to profile example. ([#575](https://github.com/getsentry/vroom/pull/575))
 - Add default non-root user in the Docker image. ([#593](https://github.com/getsentry/vroom/pull/593))
 - Classify macOS frames from an application as application frames. ([#604](https://github.com/getsentry/vroom/pull/604))
-- Return number of occurrences in flamegraph. ([#622](https://github.com/getsentry/vroom/pull/622))
+- Return number of occurrences in flamegraph. ([#622](https://github.com/getsentry/vroom/pull/622), [#625](https://github.com/getsentry/vroom/pull/625))
 
 **Bug Fixes**:
 

--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -41,7 +41,7 @@ type (
 
 		EndNS       uint64                                `json:"-"`
 		Frame       frame.Frame                           `json:"-"`
-		Occurrence  int                                   `json:"-"`
+		Occurrence  uint32                                `json:"-"`
 		SampleCount int                                   `json:"-"`
 		StartNS     uint64                                `json:"-"`
 		ProfileIDs  map[string]struct{}                   `json:"profile_ids,omitempty"`
@@ -73,6 +73,27 @@ func NodeFromFrame(f frame.Frame, start, end, fingerprint uint64) *Node {
 		n.DurationNS = n.EndNS - n.StartNS
 	}
 	return &n
+}
+
+func (n *Node) ShallowCopyWithoutChildren() *Node {
+	clone := Node{
+		EndNS:         n.EndNS,
+		Fingerprint:   n.Fingerprint,
+		Frame:         n.Frame,
+		IsApplication: n.IsApplication,
+		Line:          n.Line,
+		Name:          n.Name,
+		Package:       n.Package,
+		Path:          n.Path,
+		Occurrence:    n.Occurrence,
+		SampleCount:   n.SampleCount,
+		StartNS:       n.StartNS,
+		ProfileIDs:    n.ProfileIDs,
+		Profiles:      n.Profiles,
+		DurationNS:    n.DurationNS,
+	}
+
+	return &clone
 }
 
 func (n *Node) Update(timestamp uint64) {

--- a/internal/speedscope/speedscope.go
+++ b/internal/speedscope/speedscope.go
@@ -37,6 +37,11 @@ type (
 		Path          string `json:"path,omitempty"`
 	}
 
+	FrameInfo struct {
+		Count  uint32 `json:"count"`
+		Weight uint64 `json:"weight"`
+	}
+
 	Event struct {
 		Type  EventType `json:"type"`
 		Frame int       `json:"frame"`
@@ -76,11 +81,11 @@ type (
 		Weights           []uint64         `json:"weights"`
 		SampleDurationsNs []uint64         `json:"sample_durations_ns"`
 		SampleCounts      []uint64         `json:"sample_counts,omitempty"`
-		Occurrences       []uint64         `json:"occurrences,omitempty"`
 	}
 
 	SharedData struct {
 		Frames     []Frame                    `json:"frames"`
+		FrameInfos []FrameInfo                `json:"frame_infos"`
 		ProfileIDs []string                   `json:"profile_ids,omitempty"`
 		Profiles   []examples.ExampleMetadata `json:"profiles,omitempty"`
 	}


### PR DESCRIPTION
After playing around with #622, it doesn't actually work because a single occurrence can span multiple stacks. This reverts parts of those changes and favours annotating some metadata indicating the number of calls and the duration of a frame.