### PR TITLE
fix(flamegraph): Remove functions with zero self time at the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Add default non-root user in the Docker image. ([#593](https://github.com/getsentry/vroom/pull/593))
 - Classify macOS frames from an application as application frames. ([#604](https://github.com/getsentry/vroom/pull/604))
 - Return number of occurrences in flamegraph. ([#622](https://github.com/getsentry/vroom/pull/622), [#625](https://github.com/getsentry/vroom/pull/625))
-- Use function duration when computing metrics ([#627](https://github.com/getsentry/vroom/pull/627), [#628](https://github.com/getsentry/vroom/pull/628), [#629](https://github.com/getsentry/vroom/pull/629))
+- Use function duration when computing metrics ([#627](https://github.com/getsentry/vroom/pull/627), [#628](https://github.com/getsentry/vroom/pull/628), [#629](https://github.com/getsentry/vroom/pull/629), [#630](https://github.com/getsentry/vroom/pull/630))
 
 **Bug Fixes**:
 

--- a/internal/flamegraph/flamegraph_test.go
+++ b/internal/flamegraph/flamegraph_test.go
@@ -353,6 +353,153 @@ func TestFlamegraphAggregation(t *testing.T) {
 					SumSelfTime: 20,
 					Count:       7,
 				},
+				{
+					Name:        "a",
+					Package:     "test.package",
+					Fingerprint: 2430275452,
+					InApp:       true,
+					P75:         90,
+					P95:         90,
+					P99:         90,
+					Avg:         90,
+					Sum:         90,
+					SumSelfTime: 20,
+					Count:       9,
+				},
+			},
+		},
+		{
+			name: "zero self time",
+			profiles: []sample.Profile{
+				{
+					RawProfile: sample.RawProfile{
+						EventID:  "ab1",
+						Platform: platform.Cocoa,
+						Version:  "1",
+						Trace: sample.Trace{
+							Frames: []frame.Frame{
+								{
+									Function: "a",
+									Package:  "test.package",
+									InApp:    &testutil.True,
+								},
+								{
+									Function: "b",
+									Package:  "test.package",
+									InApp:    &testutil.True,
+								},
+								{
+									Function: "c",
+									Package:  "test.package",
+									InApp:    &testutil.True,
+								},
+							}, // end frames
+							Stacks: []sample.Stack{
+								{2, 1, 0}, // c,b,a
+								{1},       // b
+							},
+							Samples: []sample.Sample{
+								{
+									ElapsedSinceStartNS: 0,
+									StackID:             0,
+								},
+								{
+									ElapsedSinceStartNS: 10,
+									StackID:             0,
+								},
+								{
+									ElapsedSinceStartNS: 20,
+									StackID:             0,
+								},
+								{
+									ElapsedSinceStartNS: 30,
+									StackID:             1,
+								},
+								{
+									ElapsedSinceStartNS: 40,
+									StackID:             1,
+								},
+								{
+									ElapsedSinceStartNS: 50,
+									StackID:             1,
+								},
+							}, // end Samples
+						}, // end Trace
+					},
+				}, // end prof definition
+			},
+			output: speedscope.Output{
+				Metadata: speedscope.ProfileMetadata{
+					ProfileView: speedscope.ProfileView{
+						ProjectID: 99,
+					},
+				},
+				Profiles: []interface{}{
+					speedscope.SampledProfile{
+						EndValue:     5,
+						IsMainThread: true,
+						Samples: [][]int{
+							{1},
+							{0, 1, 2},
+						},
+						SamplesProfiles: [][]int{
+							{},
+							{},
+						},
+						SamplesExamples: [][]int{
+							{0},
+							{0},
+						},
+						Type:              "sampled",
+						Unit:              "count",
+						Weights:           []uint64{2, 3},
+						SampleCounts:      []uint64{2, 3},
+						SampleDurationsNs: []uint64{20, 30},
+					},
+				},
+				Shared: speedscope.SharedData{
+					Frames: []speedscope.Frame{
+						{Image: "test.package", Name: "a", Fingerprint: 2430275452, IsApplication: true},
+						{Image: "test.package", Name: "b", Fingerprint: 2430275455, IsApplication: true},
+						{Image: "test.package", Name: "c", Fingerprint: 2430275454, IsApplication: true},
+					},
+					FrameInfos: []speedscope.FrameInfo{
+						{Count: 1, Weight: 30},
+						{Count: 2, Weight: 50},
+						{Count: 1, Weight: 30},
+					},
+					Profiles: []examples.ExampleMetadata{
+						{ProfileID: "ab1"},
+					},
+				},
+			},
+			metrics: []examples.FunctionMetrics{
+				{
+					Name:        "c",
+					Package:     "test.package",
+					Fingerprint: 2430275454,
+					InApp:       true,
+					P75:         30,
+					P95:         30,
+					P99:         30,
+					Avg:         30,
+					Sum:         30,
+					SumSelfTime: 30,
+					Count:       3,
+				},
+				{
+					Name:        "b",
+					Package:     "test.package",
+					Fingerprint: 2430275455,
+					InApp:       true,
+					P75:         30,
+					P95:         30,
+					P99:         30,
+					Avg:         25,
+					Sum:         50,
+					SumSelfTime: 20,
+					Count:       5,
+				},
 			},
 		},
 	}
@@ -379,7 +526,7 @@ func TestFlamegraphAggregation(t *testing.T) {
 			ma := metrics.NewAggregator(
 				100,
 				5,
-				1,
+				0,
 			)
 
 			for _, sp := range test.profiles {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -157,6 +157,11 @@ func mergeAndSortFunctions(
 ) []nodetree.CallTreeFunction {
 	functionsList := make([]nodetree.CallTreeFunction, 0, len(functions))
 	for _, function := range functions {
+		// We collect all functions in order to collect all durations.
+		// If at the end, the self time is still 0, then it is omitted from the results.
+		if function.SumSelfTimeNS == 0 {
+			continue
+		}
 		if function.SampleCount <= 1 {
 			// if there's only ever a single sample for this function in
 			// the profile, we skip over it to reduce the amount of data

--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -239,15 +239,6 @@ func (n *Node) CollectFunctions(
 		results[fingerprint] = function
 	}
 
-	// now that we've traversed the whole tree, remove all entries with 0 self time
-	if nodeDepth == 0 {
-		for fingerprint, function := range results {
-			if function.SumSelfTimeNS == 0 {
-				delete(results, fingerprint)
-			}
-		}
-	}
-
 	// this pair represents the time spent in application functions vs
 	// time spent in system functions by this function and all of its descendents
 	return applicationDurationNS, n.DurationNS - applicationDurationNS

--- a/internal/nodetree/nodetree_test.go
+++ b/internal/nodetree/nodetree_test.go
@@ -162,6 +162,15 @@ func TestNodeTreeCollectFunctions(t *testing.T) {
 				},
 			},
 			want: map[uint32]CallTreeFunction{
+				fingerprintBar: {
+					Fingerprint:   fingerprintBar,
+					Function:      "bar",
+					Package:       "bar",
+					DurationsNS:   []uint64{10},
+					SelfTimesNS:   []uint64{},
+					SumDurationNS: 10,
+					MaxDuration:   0,
+				},
 				fingerprintFoo: {
 					Fingerprint:   fingerprintFoo,
 					InApp:         true,
@@ -183,6 +192,17 @@ func TestNodeTreeCollectFunctions(t *testing.T) {
 					SelfTimesNS:   []uint64{10},
 					SumSelfTimeNS: 10,
 					MaxDuration:   10,
+				},
+				fingerprintMain: {
+					Fingerprint:   fingerprintMain,
+					InApp:         true,
+					Function:      "main",
+					Package:       "main",
+					DurationsNS:   []uint64{10},
+					SumDurationNS: 10,
+					SelfTimesNS:   []uint64{},
+					SumSelfTimeNS: 0,
+					MaxDuration:   0,
 				},
 			},
 		},
@@ -272,6 +292,15 @@ func TestNodeTreeCollectFunctions(t *testing.T) {
 				},
 			},
 			want: map[uint32]CallTreeFunction{
+				fingerprintBar: {
+					Fingerprint:   fingerprintBar,
+					Function:      "bar",
+					Package:       "bar",
+					DurationsNS:   []uint64{10, 20},
+					SelfTimesNS:   []uint64{},
+					SumDurationNS: 30,
+					MaxDuration:   0,
+				},
 				fingerprintFoo: {
 					Fingerprint:   fingerprintFoo,
 					InApp:         true,


### PR DESCRIPTION
If the functions with 0 self time is removed immediately, it's duration won't be used to compute the metrics leading to some discrepancies.