### PR TITLE
chore(flamegraph): Remove unused profile ids from speedscope

### DIFF
--- a/internal/chunk/sample_test.go
+++ b/internal/chunk/sample_test.go
@@ -48,7 +48,6 @@ func TestCallTrees(t *testing.T) {
 						SampleCount:   2,
 						StartNS:       10_000_000,
 						Frame:         frame.Frame{Function: "function0"},
-						ProfileIDs:    make(map[string]struct{}),
 						Profiles:      make(map[examples.ExampleMetadata]struct{}),
 						Children: []*nodetree.Node{
 							{
@@ -61,7 +60,6 @@ func TestCallTrees(t *testing.T) {
 								Occurrence:    1,
 								SampleCount:   2,
 								Frame:         frame.Frame{Function: "function1"},
-								ProfileIDs:    make(map[string]struct{}),
 								Profiles:      make(map[examples.ExampleMetadata]struct{}),
 								Children: []*nodetree.Node{
 									{
@@ -74,7 +72,6 @@ func TestCallTrees(t *testing.T) {
 										SampleCount:   1,
 										StartNS:       40_000_000,
 										Frame:         frame.Frame{Function: "function2"},
-										ProfileIDs:    make(map[string]struct{}),
 										Profiles:      make(map[examples.ExampleMetadata]struct{}),
 									},
 								},
@@ -115,7 +112,6 @@ func TestCallTrees(t *testing.T) {
 						SampleCount:   1,
 						StartNS:       10_000_000,
 						Frame:         frame.Frame{Function: "function0"},
-						ProfileIDs:    make(map[string]struct{}),
 						Profiles:      make(map[examples.ExampleMetadata]struct{}),
 						Children: []*nodetree.Node{
 							{
@@ -128,7 +124,6 @@ func TestCallTrees(t *testing.T) {
 								SampleCount:   1,
 								StartNS:       10_000_000,
 								Frame:         frame.Frame{Function: "function1"},
-								ProfileIDs:    make(map[string]struct{}),
 								Profiles:      make(map[examples.ExampleMetadata]struct{}),
 							},
 						},
@@ -169,7 +164,6 @@ func TestCallTrees(t *testing.T) {
 						SampleCount:   1,
 						StartNS:       10_000_000,
 						Frame:         frame.Frame{Function: "function0"},
-						ProfileIDs:    make(map[string]struct{}),
 						Profiles:      make(map[examples.ExampleMetadata]struct{}),
 					},
 					{
@@ -182,7 +176,6 @@ func TestCallTrees(t *testing.T) {
 						SampleCount:   1,
 						StartNS:       20_000_000,
 						Frame:         frame.Frame{Function: "function1"},
-						ProfileIDs:    make(map[string]struct{}),
 						Profiles:      make(map[examples.ExampleMetadata]struct{}),
 					},
 				},

--- a/internal/flamegraph/flamegraph_test.go
+++ b/internal/flamegraph/flamegraph_test.go
@@ -148,12 +148,6 @@ func TestFlamegraphAggregation(t *testing.T) {
 							{2, 0},
 							{0, 1},
 						},
-						SamplesProfiles: [][]int{
-							{},
-							{},
-							{},
-							{},
-						},
 						SamplesExamples: [][]int{
 							{0},
 							{1},
@@ -292,11 +286,6 @@ func TestFlamegraphAggregation(t *testing.T) {
 							{0},
 							{0, 1, 2},
 							{0, 1},
-						},
-						SamplesProfiles: [][]int{
-							{},
-							{},
-							{},
 						},
 						SamplesExamples: [][]int{
 							{0},
@@ -442,10 +431,6 @@ func TestFlamegraphAggregation(t *testing.T) {
 							{1},
 							{0, 1, 2},
 						},
-						SamplesProfiles: [][]int{
-							{},
-							{},
-						},
 						SamplesExamples: [][]int{
 							{0},
 							{0},
@@ -589,7 +574,6 @@ func TestAnnotatingWithExamples(t *testing.T) {
 					SampleCount:   2,
 					Occurrence:    2,
 					Frame:         frame.Frame{Function: "function1"},
-					ProfileIDs:    make(map[string]struct{}),
 					Profiles:      make(map[examples.ExampleMetadata]struct{}),
 					Children: []*nodetree.Node{
 						{
@@ -602,7 +586,6 @@ func TestAnnotatingWithExamples(t *testing.T) {
 							Occurrence:    1,
 							StartNS:       40_000_000,
 							Frame:         frame.Frame{Function: "function2"},
-							ProfileIDs:    make(map[string]struct{}),
 							Profiles:      make(map[examples.ExampleMetadata]struct{}),
 						},
 					},
@@ -626,7 +609,6 @@ func TestAnnotatingWithExamples(t *testing.T) {
 							{0, 1},
 							{0},
 						},
-						SamplesProfiles:   [][]int{{}, {}},
 						SamplesExamples:   [][]int{{0, 1}, {0, 1}},
 						Type:              "sampled",
 						Unit:              "count",

--- a/internal/nodetree/nodetree.go
+++ b/internal/nodetree/nodetree.go
@@ -44,7 +44,6 @@ type (
 		Occurrence  uint32                                `json:"-"`
 		SampleCount int                                   `json:"-"`
 		StartNS     uint64                                `json:"-"`
-		ProfileIDs  map[string]struct{}                   `json:"profile_ids,omitempty"`
 		Profiles    map[examples.ExampleMetadata]struct{} `json:"profiles,omitempty"`
 	}
 )
@@ -66,7 +65,6 @@ func NodeFromFrame(f frame.Frame, start, end, fingerprint uint64) *Node {
 		Occurrence:    1,
 		SampleCount:   1,
 		StartNS:       start,
-		ProfileIDs:    map[string]struct{}{},
 		Profiles:      map[examples.ExampleMetadata]struct{}{},
 	}
 	if end > 0 {
@@ -88,7 +86,6 @@ func (n *Node) ShallowCopyWithoutChildren() *Node {
 		Occurrence:    n.Occurrence,
 		SampleCount:   n.SampleCount,
 		StartNS:       n.StartNS,
-		ProfileIDs:    n.ProfileIDs,
 		Profiles:      n.Profiles,
 		DurationNS:    n.DurationNS,
 	}

--- a/internal/profile/android_test.go
+++ b/internal/profile/android_test.go
@@ -708,7 +708,7 @@ func TestCallTrees(t *testing.T) {
 	}
 
 	options := cmp.Options{
-		cmpopts.IgnoreFields(nodetree.Node{}, "Fingerprint", "ProfileIDs", "Profiles"),
+		cmpopts.IgnoreFields(nodetree.Node{}, "Fingerprint", "Profiles"),
 		cmpopts.IgnoreFields(frame.Frame{}, "File"),
 	}
 

--- a/internal/sample/sample_test.go
+++ b/internal/sample/sample_test.go
@@ -387,7 +387,6 @@ func TestCallTrees(t *testing.T) {
 						SampleCount:   2,
 						StartNS:       10,
 						Frame:         frame.Frame{Function: "function0"},
-						ProfileIDs:    make(map[string]struct{}),
 						Profiles:      make(map[examples.ExampleMetadata]struct{}),
 						Children: []*nodetree.Node{
 							{
@@ -400,7 +399,6 @@ func TestCallTrees(t *testing.T) {
 								Occurrence:    1,
 								SampleCount:   2,
 								Frame:         frame.Frame{Function: "function1"},
-								ProfileIDs:    make(map[string]struct{}),
 								Profiles:      make(map[examples.ExampleMetadata]struct{}),
 								Children: []*nodetree.Node{
 									{
@@ -413,7 +411,6 @@ func TestCallTrees(t *testing.T) {
 										SampleCount:   1,
 										StartNS:       40,
 										Frame:         frame.Frame{Function: "function2"},
-										ProfileIDs:    make(map[string]struct{}),
 										Profiles:      make(map[examples.ExampleMetadata]struct{}),
 									},
 								},
@@ -457,7 +454,6 @@ func TestCallTrees(t *testing.T) {
 						SampleCount:   1,
 						StartNS:       10,
 						Frame:         frame.Frame{Function: "function0"},
-						ProfileIDs:    make(map[string]struct{}),
 						Profiles:      make(map[examples.ExampleMetadata]struct{}),
 						Children: []*nodetree.Node{
 							{
@@ -470,7 +466,6 @@ func TestCallTrees(t *testing.T) {
 								SampleCount:   1,
 								StartNS:       10,
 								Frame:         frame.Frame{Function: "function1"},
-								ProfileIDs:    make(map[string]struct{}),
 								Profiles:      make(map[examples.ExampleMetadata]struct{}),
 							},
 						},
@@ -514,7 +509,6 @@ func TestCallTrees(t *testing.T) {
 						SampleCount:   1,
 						StartNS:       10,
 						Frame:         frame.Frame{Function: "function0"},
-						ProfileIDs:    make(map[string]struct{}),
 						Profiles:      make(map[examples.ExampleMetadata]struct{}),
 					},
 					{
@@ -527,7 +521,6 @@ func TestCallTrees(t *testing.T) {
 						SampleCount:   1,
 						StartNS:       20,
 						Frame:         frame.Frame{Function: "function1"},
-						ProfileIDs:    make(map[string]struct{}),
 						Profiles:      make(map[examples.ExampleMetadata]struct{}),
 					},
 				},
@@ -1270,7 +1263,6 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 						Package:       "foo",
 						Occurrence:    1,
 						SampleCount:   1,
-						ProfileIDs:    map[string]struct{}{},
 						Profiles:      make(map[examples.ExampleMetadata]struct{}),
 						Frame: frame.Frame{
 							Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
@@ -1326,7 +1318,6 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 						Package:       "foo",
 						Occurrence:    1,
 						SampleCount:   1,
-						ProfileIDs:    map[string]struct{}{},
 						Profiles:      make(map[examples.ExampleMetadata]struct{}),
 						Frame: frame.Frame{
 							Data:     frame.Data{SymbolicatorStatus: "symbolicated"},
@@ -1385,7 +1376,6 @@ func TestCallTreesFingerprintPerPlatform(t *testing.T) {
 						Path:          "/usr/local/lib/python3.8/threading.py",
 						Occurrence:    1,
 						SampleCount:   1,
-						ProfileIDs:    map[string]struct{}{},
 						Profiles:      make(map[examples.ExampleMetadata]struct{}),
 						Frame: frame.Frame{
 							Function: "Threading.run",

--- a/internal/speedscope/speedscope.go
+++ b/internal/speedscope/speedscope.go
@@ -72,7 +72,6 @@ type (
 		Priority          int              `json:"priority,omitempty"`
 		Queues            map[string]Queue `json:"queues,omitempty"`
 		Samples           [][]int          `json:"samples"`
-		SamplesProfiles   [][]int          `json:"samples_profiles,omitempty"`
 		SamplesExamples   [][]int          `json:"samples_examples,omitempty"`
 		StartValue        uint64           `json:"startValue"`
 		State             string           `json:"state,omitempty"`
@@ -87,7 +86,6 @@ type (
 	SharedData struct {
 		Frames     []Frame                    `json:"frames"`
 		FrameInfos []FrameInfo                `json:"frame_infos"`
-		ProfileIDs []string                   `json:"profile_ids,omitempty"`
 		Profiles   []examples.ExampleMetadata `json:"profiles,omitempty"`
 	}
 


### PR DESCRIPTION
Profile ids were used for transaction profiles. Since continuous profiling, we've moved to profiles where it contains metadata indicating either a transaction profile or a continuous profile.

#skip-changelog