### PR TITLE
ref: fixes changelog bump entry

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -20,4 +20,3 @@ targets:
     source: ghcr.io/getsentry/vroom
     target: getsentry/vroom
     targetFormat: '{{{target}}}:latest'
-preReleaseCommand: ""

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "Vroom can only be released on Linux!"
+    echo "Please use the GitHub Action instead."
+    exit 1
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+OLD_VERSION="${1}"
+NEW_VERSION="${2}"
+
+echo "Current version: ${OLD_VERSION}"
+echo "Bumping version: ${NEW_VERSION}"


### PR DESCRIPTION
Vroom's CHANGELOG is broken since 2 years ago. Let's fix it.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
