### PR TITLE
feat(build): add action-build-and-push-images to build production images published to GAR (part 1)

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -139,3 +139,30 @@ jobs:
           project_name: vroom
           image_url: ghcr.io/getsentry/vroom:${{ github.sha }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+
+  build-production:
+    runs-on: ubuntu-24.04
+    if: github.ref_name == github.event.repository.default_branch
+    name: Build and push production images
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build and push image
+        uses: getsentry/action-build-and-push-images@a53f146fc1ea3cb404f2dcf7378f5b60dd98d3ca
+        with:
+          image_name: 'vroom'
+          platforms: linux/amd64
+          dockerfile_path: './Dockerfile'
+          ghcr: false
+          google_ar: true
+          tag_nightly: false
+          tag_latest: true
+          # TODO: remove this once we cut over GoCD to using gha for prod images
+          tag_suffix: -gha
+          google_ar_image_name: us-central1-docker.pkg.dev/sentryio/vroom/vroom
+          google_workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
+          google_service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com


### PR DESCRIPTION
the goal is to comply with the artifact management standard here: https://www.notion.so/sentry/Standard-Spec-Artifact-Management-22a8b10e4b5d80ecb6dcca3eb4558f5b

this is step 1 of 3:
1. add our composite action which will build images in GHA and publish to GAR
- these images temporarily have a -gha suffix so GoCD won't deploy them
2. add -cloudbuild suffix to cloudbuilds to disable use of them and remove -gha so GoCD cuts over to using images in GAR
3. delete cloudbuild

