### PR TITLE
ci: tag latest version only for calver release

### DIFF
--- a/.github/workflows/release-ghcr-version-tag.yaml
+++ b/.github/workflows/release-ghcr-version-tag.yaml
@@ -20,3 +20,9 @@ jobs:
           docker buildx imagetools create --tag \
            ghcr.io/getsentry/vroom:${{ github.ref_name }} \
            ghcr.io/getsentry/vroom:${{ github.sha }}
+
+      - name: Tag latest version
+        run: |
+          docker buildx imagetools create --tag \
+           ghcr.io/getsentry/vroom:latest \
+           ghcr.io/getsentry/vroom:${{ github.sha }}


### PR DESCRIPTION
latest should point at CalVer release, and nightly should point at master/main branch. We're cleaning things up for self-hosted users.
