### PR TITLE
ref(build): delete cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,0 @@
-steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args: [
-    'build',
-    '-t', 'us-central1-docker.pkg.dev/sentryio/vroom/vroom:$COMMIT_SHA-cloudbuild',
-    '.',
-  ]


### PR DESCRIPTION
part 3 of https://github.com/getsentry/vroom/pull/645

i've checked gocd, a deploy successfully went out using a GAR image that was built by the composite action; cloudbuild is no longer relevant

#skip-changelog