### PR TITLE
feat(devservices): Use nighty image for devservices

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -14,7 +14,7 @@ x-sentry-service-config:
     default: [kafka, vroom]
 services:
   vroom:
-    image: us-central1-docker.pkg.dev/sentryio/vroom/vroom:latest
+    image: ghcr.io/getsentry/vroom:nightly
     ports:
       - 127.0.0.1:8085:8085
     environment:


### PR DESCRIPTION
GHCR houses multiplatform images which is better for development, and we should standardize on using ghcr for ci and dev

#skip-changelog