### PR TITLE
ci: upgrade to action-setup-venv 3.2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,9 +58,8 @@ jobs:
           # we just cache the venv-dir directly in action-setup-venv
           enable-cache: false
 
-      - uses: getsentry/action-setup-venv@0958463ee0e02b9e8aa8f8e031afae1f84b80881 # v3.0.0
+      - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         with:
-          python-version: 3.13.5
           cache-dependency-path: uv.lock
           install-cmd: uv sync --frozen --only-dev --active
 


### PR DESCRIPTION
recently had to spend time debugging something silly in https://github.com/getsentry/sentry-kafka-schemas/pull/465 which wouldn't have been an issue if we were using a more modern version of this which infers the python version from .python-version