### PR TITLE
ref(vroom): Remove unused `MetricSummary` struct

### DIFF
--- a/cmd/vroom/utils.go
+++ b/cmd/vroom/utils.go
@@ -15,13 +15,6 @@ import (
 	"github.com/segmentio/kafka-go/sasl/scram"
 )
 
-type MetricSummary struct {
-	Min   float64
-	Max   float64
-	Sum   float64
-	Count uint64
-}
-
 func createKafkaRoundTripper(e ServiceConfig) kafka.RoundTripper {
 	var saslMechanism sasl.Mechanism
 	var tlsConfig *tls.Config


### PR DESCRIPTION
This has been unused since https://github.com/getsentry/vroom/pull/534. Remove it.

#skip-changelog