### PR TITLE
Match common repo_link format

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -7,7 +7,7 @@ x-sentry-service-config:
       remote:
         repo_name: sentry-shared-kafka
         branch: main
-        repo_link: git@github.com:getsentry/sentry-shared-kafka.git
+        repo_link: https://github.com/getsentry/sentry-shared-kafka.git
     vroom:
       description: Sentry's profiling service, processing and deriving data about your profiles
   modes:


### PR DESCRIPTION
Normally we use the `https://` format for `repo_link` rather than `git@origin:`

So:
```
https://github.com/getsentry/sentry-shared-kafka.git
```

Rather than:
```
git@github.com:getsentry/sentry-shared-kafka.git
```

This has caused an issue in the past for example see https://github.com/getsentry/devservices/pull/322

#skip-changelog
